### PR TITLE
Ability to configure guards before publishing data to Ingest API

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -125,6 +125,8 @@ stages:
     jobs:
       - job: Build
         displayName: Build
+        pool:
+          vmImage: ubuntu-latest
         steps:
 
           # Restore packages
@@ -169,7 +171,7 @@ stages:
         displayName: Release on NuGet.org
         environment: NuGetOrg
         pool:
-          vmImage: ubuntu-18.04
+          vmImage: ubuntu-latest
         strategy:
           runOnce:
             deploy:

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/DataPropertyValueConverter/CompositionExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/DataPropertyValueConverter/CompositionExtensions.cs
@@ -1,13 +1,24 @@
-﻿using Umbraco.Core.Composing;
+﻿using Enterspeed.Source.UmbracoCms.V8.Guards;
+using Umbraco.Core.Composing;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Components.DataPropertyValueConverter
 {
     public static class CompositionExtensions
     {
-        public static EnterspeedPropertyValueConverterCollectionBuilder EnterspeedPropertyValueConverters(this Composition composition)
+        public static EnterspeedPropertyValueConverterCollectionBuilder EnterspeedPropertyValueConverters(
+            this Composition composition)
             => composition.WithCollectionBuilder<EnterspeedPropertyValueConverterCollectionBuilder>();
 
-        public static EnterspeedGridEditorValueConverterCollectionBuilder EnterspeedGridEditorValueConverters(this Composition composition)
+        public static EnterspeedGridEditorValueConverterCollectionBuilder EnterspeedGridEditorValueConverters(
+            this Composition composition)
             => composition.WithCollectionBuilder<EnterspeedGridEditorValueConverterCollectionBuilder>();
+
+        public static EnterspeedContentHandlingGuardCollectionBuilder EnterspeedContentHandlingGuards(
+            this Composition composition)
+            => composition.WithCollectionBuilder<EnterspeedContentHandlingGuardCollectionBuilder>();
+
+        public static EnterspeedDictionaryItemHandlingGuardCollectionBuilder EnterspeedDictionaryItemHandlingGuards(
+            this Composition composition)
+            => composition.WithCollectionBuilder<EnterspeedDictionaryItemHandlingGuardCollectionBuilder>();
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
@@ -9,6 +9,7 @@ using Enterspeed.Source.UmbracoCms.V8.Components.DataPropertyValueConverter;
 using Enterspeed.Source.UmbracoCms.V8.Data.MappingDefinitions;
 using Enterspeed.Source.UmbracoCms.V8.Data.Repositories;
 using Enterspeed.Source.UmbracoCms.V8.Extensions;
+using Enterspeed.Source.UmbracoCms.V8.Guards;
 using Enterspeed.Source.UmbracoCms.V8.Handlers;
 using Enterspeed.Source.UmbracoCms.V8.Providers;
 using Enterspeed.Source.UmbracoCms.V8.Services;
@@ -34,6 +35,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
 
             composition.Register<IEnterspeedPropertyService, EnterspeedPropertyService>(Lifetime.Transient);
             composition.Register<IEnterspeedGridEditorService, EnterspeedGridEditorService>(Lifetime.Transient);
+
             composition.Register<IEnterspeedJobRepository, EnterspeedJobRespository>(Lifetime.Request);
             composition.Register<IEnterspeedJobHandler, EnterspeedJobHandler>(Lifetime.Request);
             composition.Register<IUmbracoUrlService, UmbracoUrlService>(Lifetime.Request);
@@ -46,6 +48,8 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
             composition.Register<IJsonSerializer, SystemTextJsonSerializer>(Lifetime.Singleton);
             composition.Register<IUmbracoMediaUrlProvider, UmbracoMediaUrlProvider>(Lifetime.Request);
             composition.Register<IUmbracoRedirectsService, UmbracoRedirectsService>(Lifetime.Request);
+            composition.Register<IUmbracoRedirectsService, UmbracoRedirectsService>(Lifetime.Request);
+            composition.Register<IEnterspeedGuardService, EnterspeedGuardService>(Lifetime.Request);
 
             composition.Register<IEnterspeedConnection>(
                 c =>
@@ -84,15 +88,22 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
                 .Append<DefaultTextboxPropertyValueConverter>()
                 .Append<DefaultUserPickerPropertyValueConverter>();
 
-            // Default grid editor value convertres
+            // Default grid editor value converters
             composition.EnterspeedGridEditorValueConverters()
                 .Append<DefaultRichTextEditorGridEditorValueConverter>();
+
+            // Content handling guards
+            composition.EnterspeedContentHandlingGuards()
+                .Append<ContentCultureUrlRequiredGuard>();
+
+            // Dictionary items handling guards
+            composition.EnterspeedDictionaryItemHandlingGuards();
 
             // Mapping definitions
             composition.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
                 .Add<EnterspeedJobMappingDefinition>();
 
-            // Register event componenents
+            // Register event components
             composition.Components().Append<EnterspeedContentEventsComponent>();
             composition.Components().Append<EnterspeedJobsComponent>();
             composition.Components().Append<EnterspeedBackgroundTasksComponent>();

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -294,6 +294,13 @@
     <Compile Include="Data\Schemas\EnterspeedJobSchema.cs" />
     <Compile Include="Extensions\PropertyExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Guards\ContentCultureUrlRequiredGuard.cs" />
+    <Compile Include="Guards\EnterspeedContentHandlingGuardCollection.cs" />
+    <Compile Include="Guards\EnterspeedContentHandlingGuardCollectionBuilder.cs" />
+    <Compile Include="Guards\EnterspeedDictionaryItemHandlingGuardCollection.cs" />
+    <Compile Include="Guards\EnterspeedDictionaryItemHandlingGuardCollectionBuilder.cs" />
+    <Compile Include="Guards\IEnterspeedContentHandlingGuard.cs" />
+    <Compile Include="Guards\IEnterspeedDictionaryItemHandlingGuard.cs" />
     <Compile Include="Handlers\EnterspeedJobHandler.cs" />
     <Compile Include="Handlers\IEnterspeedJobHandler.cs" />
     <Compile Include="Models\Api\ApiResponse.cs" />
@@ -330,6 +337,7 @@
     <Compile Include="Services\DataProperties\DefaultConverters\DefaultTextAreaPropertyValueConverter.cs" />
     <Compile Include="Services\DataProperties\DefaultGridConverters\DefaultRichTextEditorGridEditorValueConverter.cs" />
     <Compile Include="Services\DataProperties\IEnterspeedGridEditorValueConverter.cs" />
+    <Compile Include="Services\EnterspeedGuardService.cs" />
     <Compile Include="Services\EnterspeedPropertyService.cs" />
     <Compile Include="Services\DataProperties\DefaultConverters\DefaultDropdownPropertyValueConverter.cs" />
     <Compile Include="Services\DataProperties\DefaultConverters\DefaultDecimalPropertyValueConverter.cs" />
@@ -345,6 +353,7 @@
     <Compile Include="Services\EnterspeedGridEditorService.cs" />
     <Compile Include="Services\IEnterspeedConfigurationService.cs" />
     <Compile Include="Services\IEnterspeedGridEditorService.cs" />
+    <Compile Include="Services\IEnterspeedGuardService.cs" />
     <Compile Include="Services\IEnterspeedPropertyService.cs" />
     <Compile Include="Services\IEnterspeedJobService.cs" />
     <Compile Include="Services\IEntityIdentityService.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/ContentCultureUrlRequiredGuard.cs
@@ -5,7 +5,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Guards
 {
     public class ContentCultureUrlRequiredGuard : IEnterspeedContentHandlingGuard
     {
-        public bool CanPublish(IPublishedContent content, string culture)
+        public bool CanIngest(IPublishedContent content, string culture)
         {
             if (string.IsNullOrWhiteSpace(culture))
             {

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/ContentCultureUrlRequiredGuard.cs
@@ -1,0 +1,19 @@
+using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Web;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class ContentCultureUrlRequiredGuard : IEnterspeedContentHandlingGuard
+    {
+        public bool CanPublish(IPublishedContent content, string culture)
+        {
+            if (string.IsNullOrWhiteSpace(culture))
+            {
+                return true;
+            }
+
+            var url = content.Url(culture);
+            return !string.IsNullOrWhiteSpace(url) && !url.Equals("#");
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedContentHandlingGuardCollection.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedContentHandlingGuardCollection.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class EnterspeedContentHandlingGuardCollection : BuilderCollectionBase<IEnterspeedContentHandlingGuard>
+    {
+        public EnterspeedContentHandlingGuardCollection(IEnumerable<IEnterspeedContentHandlingGuard> items)
+            : base(items)
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedContentHandlingGuardCollectionBuilder.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedContentHandlingGuardCollectionBuilder.cs
@@ -1,0 +1,15 @@
+using Umbraco.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class EnterspeedContentHandlingGuardCollectionBuilder
+        : OrderedCollectionBuilderBase<EnterspeedContentHandlingGuardCollectionBuilder, EnterspeedContentHandlingGuardCollection,
+            IEnterspeedContentHandlingGuard>
+    {
+        public EnterspeedContentHandlingGuardCollectionBuilder()
+        {
+        }
+
+        protected override EnterspeedContentHandlingGuardCollectionBuilder This => this;
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedDictionaryItemHandlingGuardCollection.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedDictionaryItemHandlingGuardCollection.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Umbraco.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class
+        EnterspeedDictionaryItemHandlingGuardCollection : BuilderCollectionBase<IEnterspeedDictionaryItemHandlingGuard>
+    {
+        public EnterspeedDictionaryItemHandlingGuardCollection(
+            IEnumerable<IEnterspeedDictionaryItemHandlingGuard> items)
+            : base(items)
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedDictionaryItemHandlingGuardCollectionBuilder.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedDictionaryItemHandlingGuardCollectionBuilder.cs
@@ -1,0 +1,16 @@
+using Umbraco.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class EnterspeedDictionaryItemHandlingGuardCollectionBuilder
+        : OrderedCollectionBuilderBase<EnterspeedDictionaryItemHandlingGuardCollectionBuilder,
+            EnterspeedDictionaryItemHandlingGuardCollection,
+            IEnterspeedDictionaryItemHandlingGuard>
+    {
+        public EnterspeedDictionaryItemHandlingGuardCollectionBuilder()
+        {
+        }
+
+        protected override EnterspeedDictionaryItemHandlingGuardCollectionBuilder This => this;
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedContentHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedContentHandlingGuard.cs
@@ -1,0 +1,15 @@
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public interface IEnterspeedContentHandlingGuard
+    {
+        /// <summary>
+        /// Validates if content can be published.
+        /// </summary>
+        /// <param name="content">Content for publishing.</param>
+        /// <param name="culture">Culture of content.</param>
+        /// <returns>True or false, if is valid for publishing or not.</returns>
+        bool CanPublish(IPublishedContent content, string culture);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedContentHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedContentHandlingGuard.cs
@@ -5,11 +5,11 @@ namespace Enterspeed.Source.UmbracoCms.V8.Guards
     public interface IEnterspeedContentHandlingGuard
     {
         /// <summary>
-        /// Validates if content can be published.
+        /// Validates if content can be ingested.
         /// </summary>
-        /// <param name="content">Content for publishing.</param>
+        /// <param name="content">Content for ingest.</param>
         /// <param name="culture">Culture of content.</param>
-        /// <returns>True or false, if is valid for publishing or not.</returns>
-        bool CanPublish(IPublishedContent content, string culture);
+        /// <returns>True or false, if is valid for ingest or not.</returns>
+        bool CanIngest(IPublishedContent content, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
@@ -1,0 +1,15 @@
+using Umbraco.Core.Models;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public interface IEnterspeedDictionaryItemHandlingGuard
+    {
+        /// <summary>
+        /// Validates if dictionary item can be published.
+        /// </summary>
+        /// <param name="dictionaryItem">Dictionary item for publishing.</param>
+        /// <param name="culture">Culture of dictionary item.</param>
+        /// <returns>True or false, if is valid for publishing or not.</returns>
+        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
@@ -5,11 +5,11 @@ namespace Enterspeed.Source.UmbracoCms.V8.Guards
     public interface IEnterspeedDictionaryItemHandlingGuard
     {
         /// <summary>
-        /// Validates if dictionary item can be published.
+        /// Validates if dictionary item can be ingested.
         /// </summary>
-        /// <param name="dictionaryItem">Dictionary item for publishing.</param>
+        /// <param name="dictionaryItem">Dictionary item for ingest.</param>
         /// <param name="culture">Culture of dictionary item.</param>
-        /// <returns>True or false, if is valid for publishing or not.</returns>
-        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+        /// <returns>True or false, if is valid for ingest or not.</returns>
+        bool CanIngest(IDictionaryItem dictionaryItem, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/EnterspeedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/EnterspeedJobHandler.cs
@@ -138,7 +138,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
                                 }
 
                                 // Check if any of guards are against it
-                                if (!_enterspeedGuardService.CanPublish(content, culture))
+                                if (!_enterspeedGuardService.CanIngest(content, culture))
                                 {
                                     // Skip it, if is not valid.
                                     continue;
@@ -175,7 +175,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
                                 }
 
                                 // Check if any of guards are against it
-                                if (!_enterspeedGuardService.CanPublish(dictionaryItem, culture))
+                                if (!_enterspeedGuardService.CanIngest(dictionaryItem, culture))
                                 {
                                     // Skip it, if is not valid.
                                     continue;

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedGuardService.cs
@@ -1,0 +1,58 @@
+using System.Linq;
+using Enterspeed.Source.UmbracoCms.V8.Guards;
+using Umbraco.Core.Logging;
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Services
+{
+    public class EnterspeedGuardService : IEnterspeedGuardService
+    {
+        private readonly ILogger _logger;
+        private readonly EnterspeedContentHandlingGuardCollection _contentGuards;
+        private readonly EnterspeedDictionaryItemHandlingGuardCollection _dictionaryItemGuards;
+
+        public EnterspeedGuardService(
+            EnterspeedContentHandlingGuardCollection contentGuards,
+            EnterspeedDictionaryItemHandlingGuardCollection dictionaryItemGuards,
+            ILogger logger)
+        {
+            _contentGuards = contentGuards;
+            _dictionaryItemGuards = dictionaryItemGuards;
+            _logger = logger;
+        }
+
+        public bool CanPublish(IPublishedContent content, string culture)
+        {
+            var blockingGuard = _contentGuards.FirstOrDefault(guard => !guard.CanPublish(content, culture));
+            if (blockingGuard == null)
+            {
+                return true;
+            }
+
+            _logger.Debug<EnterspeedGuardService>(
+                "Content {contentId} with {culture} culture, publishing avoided by '{guard}'.",
+                content.Id,
+                culture,
+                blockingGuard.GetType().Name);
+            return false;
+        }
+
+        public bool CanPublish(IDictionaryItem dictionaryItem, string culture)
+        {
+            var blockingGuard =
+                _dictionaryItemGuards.FirstOrDefault(guard => !guard.CanPublish(dictionaryItem, culture));
+            if (blockingGuard == null)
+            {
+                return true;
+            }
+
+            _logger.Debug<EnterspeedGuardService>(
+                "Dictionary item {dictionaryItemId} with {culture} culture, publishing avoided by '{guard}'.",
+                dictionaryItem.Id,
+                culture,
+                blockingGuard.GetType().Name);
+            return false;
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedGuardService.cs
@@ -22,33 +22,33 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             _logger = logger;
         }
 
-        public bool CanPublish(IPublishedContent content, string culture)
+        public bool CanIngest(IPublishedContent content, string culture)
         {
-            var blockingGuard = _contentGuards.FirstOrDefault(guard => !guard.CanPublish(content, culture));
+            var blockingGuard = _contentGuards.FirstOrDefault(guard => !guard.CanIngest(content, culture));
             if (blockingGuard == null)
             {
                 return true;
             }
 
             _logger.Debug<EnterspeedGuardService>(
-                "Content {contentId} with {culture} culture, publishing avoided by '{guard}'.",
+                "Content {contentId} with {culture} culture, ingest avoided by '{guard}'.",
                 content.Id,
                 culture,
                 blockingGuard.GetType().Name);
             return false;
         }
 
-        public bool CanPublish(IDictionaryItem dictionaryItem, string culture)
+        public bool CanIngest(IDictionaryItem dictionaryItem, string culture)
         {
             var blockingGuard =
-                _dictionaryItemGuards.FirstOrDefault(guard => !guard.CanPublish(dictionaryItem, culture));
+                _dictionaryItemGuards.FirstOrDefault(guard => !guard.CanIngest(dictionaryItem, culture));
             if (blockingGuard == null)
             {
                 return true;
             }
 
             _logger.Debug<EnterspeedGuardService>(
-                "Dictionary item {dictionaryItemId} with {culture} culture, publishing avoided by '{guard}'.",
+                "Dictionary item {dictionaryItemId} with {culture} culture, ingest avoided by '{guard}'.",
                 dictionaryItem.Id,
                 culture,
                 blockingGuard.GetType().Name);

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedGuardService.cs
@@ -1,0 +1,11 @@
+using Umbraco.Core.Models;
+using Umbraco.Core.Models.PublishedContent;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Services
+{
+    public interface IEnterspeedGuardService
+    {
+        bool CanPublish(IPublishedContent content, string culture);
+        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedGuardService.cs
@@ -5,7 +5,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
 {
     public interface IEnterspeedGuardService
     {
-        bool CanPublish(IPublishedContent content, string culture);
-        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+        bool CanIngest(IPublishedContent content, string culture);
+        bool CanIngest(IDictionaryItem dictionaryItem, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Composers/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Composers/EnterspeedComposer.cs
@@ -10,6 +10,7 @@ using Enterspeed.Source.UmbracoCms.V9.Data.MappingDefinitions;
 using Enterspeed.Source.UmbracoCms.V9.Data.Repositories;
 using Enterspeed.Source.UmbracoCms.V9.DataPropertyValueConverters;
 using Enterspeed.Source.UmbracoCms.V9.Extensions;
+using Enterspeed.Source.UmbracoCms.V9.Guards;
 using Enterspeed.Source.UmbracoCms.V9.Handlers;
 using Enterspeed.Source.UmbracoCms.V9.HostedServices;
 using Enterspeed.Source.UmbracoCms.V9.NotificationHandlers;
@@ -46,6 +47,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Composers
             builder.Services.AddTransient<IEnterspeedJobService, EnterspeedJobService>();
             builder.Services.AddTransient<IUmbracoRedirectsService, UmbracoRedirectsService>();
             builder.Services.AddTransient<IEnterspeedJobHandler, EnterspeedJobHandler>();
+            builder.Services.AddTransient<IEnterspeedGuardService, EnterspeedGuardService>();
 
             builder.Services.AddSingleton<IEnterspeedIngestService, EnterspeedIngestService>();
             builder.Services.AddSingleton<IEnterspeedConfigurationService, EnterspeedConfigurationService>();
@@ -87,6 +89,13 @@ namespace Enterspeed.Source.UmbracoCms.V9.Composers
             builder.EnterspeedGridEditorValueConverters()
                 .Append<DefaultRichTextEditorGridEditorValueConverter>();
 
+            // Content handling guards
+            builder.EnterspeedContentHandlingGuards()
+                .Append<ContentCultureUrlRequiredGuard>();
+
+            // Dictionary items handling guards
+            builder.EnterspeedDictionaryItemHandlingGuards();
+
             // Mapping definitions
             builder.WithCollectionBuilder<MapDefinitionCollectionBuilder>()
                 .Add<EnterspeedJobMappingDefinition>();
@@ -110,7 +119,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Composers
                     EnterspeedDictionaryItemSavedNotificationHandler>();
 
             builder
-               .AddNotificationHandler<DictionaryItemDeletingNotification,
+                .AddNotificationHandler<DictionaryItemDeletingNotification,
                     EnterspeedDictionaryItemDeletingNotificationHandler>();
 
             // Components

--- a/src/Enterspeed.Source.UmbracoCms.V9/DataPropertyValueConverters/CompositionExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/DataPropertyValueConverters/CompositionExtensions.cs
@@ -1,4 +1,5 @@
-﻿using Umbraco.Cms.Core.DependencyInjection;
+﻿using Enterspeed.Source.UmbracoCms.V9.Guards;
+using Umbraco.Cms.Core.DependencyInjection;
 
 namespace Enterspeed.Source.UmbracoCms.V9.DataPropertyValueConverters
 {
@@ -9,5 +10,11 @@ namespace Enterspeed.Source.UmbracoCms.V9.DataPropertyValueConverters
 
         public static EnterspeedGridEditorValueConverterCollectionBuilder EnterspeedGridEditorValueConverters(this IUmbracoBuilder  composition)
             => composition.WithCollectionBuilder<EnterspeedGridEditorValueConverterCollectionBuilder>();
+        
+        public static EnterspeedContentHandlingGuardCollectionBuilder EnterspeedContentHandlingGuards(this IUmbracoBuilder  composition)
+            => composition.WithCollectionBuilder<EnterspeedContentHandlingGuardCollectionBuilder>();
+        
+        public static EnterspeedDictionaryItemHandlingGuardCollectionBuilder EnterspeedDictionaryItemHandlingGuards(this IUmbracoBuilder  composition)
+            => composition.WithCollectionBuilder<EnterspeedDictionaryItemHandlingGuardCollectionBuilder>();
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
@@ -5,7 +5,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
 {
     public class ContentCultureUrlRequiredGuard : IEnterspeedContentHandlingGuard
     {
-        public bool CanPublish(IPublishedContent content, string culture)
+        public bool CanIngest(IPublishedContent content, string culture)
         {
             if (string.IsNullOrWhiteSpace(culture))
             {

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
@@ -1,0 +1,19 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public class ContentCultureUrlRequiredGuard : IEnterspeedContentHandlingGuard
+    {
+        public bool CanPublish(IPublishedContent content, string culture)
+        {
+            if (string.IsNullOrWhiteSpace(culture))
+            {
+                return true;
+            }
+
+            var url = content.Url(culture);
+            return !string.IsNullOrWhiteSpace(url) && !url.Equals("#");
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedContentHandlingGuardCollection.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedContentHandlingGuardCollection.cs
@@ -1,0 +1,14 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public class EnterspeedContentHandlingGuardCollection : BuilderCollectionBase<IEnterspeedContentHandlingGuard>
+    {
+        public EnterspeedContentHandlingGuardCollection(Func<IEnumerable<IEnterspeedContentHandlingGuard>> items)
+            : base(items)
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedContentHandlingGuardCollectionBuilder.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedContentHandlingGuardCollectionBuilder.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public class EnterspeedContentHandlingGuardCollectionBuilder
+        : OrderedCollectionBuilderBase<EnterspeedContentHandlingGuardCollectionBuilder, EnterspeedContentHandlingGuardCollection,
+            IEnterspeedContentHandlingGuard>
+    {
+        public EnterspeedContentHandlingGuardCollectionBuilder()
+        {
+        }
+
+        protected override EnterspeedContentHandlingGuardCollectionBuilder This => this;
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedDictionaryItemHandlingGuardCollection.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedDictionaryItemHandlingGuardCollection.cs
@@ -1,0 +1,16 @@
+using System;
+using System.Collections.Generic;
+using Umbraco.Cms.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public class
+        EnterspeedDictionaryItemHandlingGuardCollection : BuilderCollectionBase<IEnterspeedDictionaryItemHandlingGuard>
+    {
+        public EnterspeedDictionaryItemHandlingGuardCollection(
+            Func<IEnumerable<IEnterspeedDictionaryItemHandlingGuard>> items)
+            : base(items)
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedDictionaryItemHandlingGuardCollectionBuilder.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/EnterspeedDictionaryItemHandlingGuardCollectionBuilder.cs
@@ -1,0 +1,16 @@
+using Umbraco.Cms.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public class EnterspeedDictionaryItemHandlingGuardCollectionBuilder
+        : OrderedCollectionBuilderBase<EnterspeedDictionaryItemHandlingGuardCollectionBuilder,
+            EnterspeedDictionaryItemHandlingGuardCollection,
+            IEnterspeedDictionaryItemHandlingGuard>
+    {
+        public EnterspeedDictionaryItemHandlingGuardCollectionBuilder()
+        {
+        }
+
+        protected override EnterspeedDictionaryItemHandlingGuardCollectionBuilder This => this;
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedContentHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedContentHandlingGuard.cs
@@ -5,11 +5,11 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
     public interface IEnterspeedContentHandlingGuard
     {
         /// <summary>
-        /// Validates if content can be published.
+        /// Validates if content can be ingested.
         /// </summary>
-        /// <param name="content">Content for publishing.</param>
+        /// <param name="content">Content for ingest.</param>
         /// <param name="culture">Culture of content.</param>
-        /// <returns>True or false, if is valid for publishing or not.</returns>
-        bool CanPublish(IPublishedContent content, string culture);
+        /// <returns>True or false, if is valid for ingest or not.</returns>
+        bool CanIngest(IPublishedContent content, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedContentHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedContentHandlingGuard.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public interface IEnterspeedContentHandlingGuard
+    {
+        /// <summary>
+        /// Validates if content can be published.
+        /// </summary>
+        /// <param name="content">Content for publishing.</param>
+        /// <param name="culture">Culture of content.</param>
+        /// <returns>True or false, if is valid for publishing or not.</returns>
+        bool CanPublish(IPublishedContent content, string culture);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
@@ -1,0 +1,15 @@
+using Umbraco.Cms.Core.Models;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Guards
+{
+    public interface IEnterspeedDictionaryItemHandlingGuard
+    {
+        /// <summary>
+        /// Validates if dictionary item can be published.
+        /// </summary>
+        /// <param name="dictionaryItem">Dictionary item for publishing.</param>
+        /// <param name="culture">Culture of dictionary item.</param>
+        /// <returns>True or false, if is valid for publishing or not.</returns>
+        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/IEnterspeedDictionaryItemHandlingGuard.cs
@@ -5,11 +5,11 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
     public interface IEnterspeedDictionaryItemHandlingGuard
     {
         /// <summary>
-        /// Validates if dictionary item can be published.
+        /// Validates if dictionary item can be ingested.
         /// </summary>
-        /// <param name="dictionaryItem">Dictionary item for publishing.</param>
+        /// <param name="dictionaryItem">Dictionary item for ingest.</param>
         /// <param name="culture">Culture of dictionary item.</param>
-        /// <returns>True or false, if is valid for publishing or not.</returns>
-        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+        /// <returns>True or false, if is valid for ingest or not.</returns>
+        bool CanIngest(IDictionaryItem dictionaryItem, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Handlers/EnterspeedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Handlers/EnterspeedJobHandler.cs
@@ -139,7 +139,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Handlers
                                 }
 
                                 // Check if any of guards are against it
-                                if (!_enterspeedGuardService.CanPublish(content, culture))
+                                if (!_enterspeedGuardService.CanIngest(content, culture))
                                 {
                                     // Skip it, if is not valid.
                                     continue;
@@ -179,7 +179,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Handlers
                                 }
                                 
                                 // Check if any of guards are against it
-                                if (!_enterspeedGuardService.CanPublish(dictionaryItem, culture))
+                                if (!_enterspeedGuardService.CanIngest(dictionaryItem, culture))
                                 {
                                     // Skip it, if is not valid.
                                     continue;

--- a/src/Enterspeed.Source.UmbracoCms.V9/NotificationHandlers/EnterspeedContentPublishingNotificationHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/NotificationHandlers/EnterspeedContentPublishingNotificationHandler.cs
@@ -33,6 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.NotificationHandlers
                   umbracoContextFactory,
                   scopeProvider)
         {
+            _contentService = contentService;
         }
 
         public void Handle(ContentPublishingNotification notification)

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedGuardService.cs
@@ -22,27 +22,27 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
             _logger = logger;
         }
 
-        public bool CanPublish(IPublishedContent content, string culture)
+        public bool CanIngest(IPublishedContent content, string culture)
         {
-            var blockingGuard = _contentGuards.FirstOrDefault(guard => !guard.CanPublish(content, culture));
+            var blockingGuard = _contentGuards.FirstOrDefault(guard => !guard.CanIngest(content, culture));
             if (blockingGuard == null)
             {
                 return true;
             }
             
-            _logger.LogDebug("Content {contentId} with {culture} culture, publishing avoided by '{guard}'.", content.Id, culture, blockingGuard.GetType().Name);
+            _logger.LogDebug("Content {contentId} with {culture} culture, ingest avoided by '{guard}'.", content.Id, culture, blockingGuard.GetType().Name);
             return false;
         }
 
-        public bool CanPublish(IDictionaryItem dictionaryItem, string culture)
+        public bool CanIngest(IDictionaryItem dictionaryItem, string culture)
         {
-            var blockingGuard = _dictionaryItemGuards.FirstOrDefault(guard => !guard.CanPublish(dictionaryItem, culture));
+            var blockingGuard = _dictionaryItemGuards.FirstOrDefault(guard => !guard.CanIngest(dictionaryItem, culture));
             if (blockingGuard == null)
             {
                 return true;
             }
             
-            _logger.LogDebug("Dictionary item {dictionaryItemId} with {culture} culture, publishing avoided by '{guard}'.", dictionaryItem.Id, culture, blockingGuard.GetType().Name);
+            _logger.LogDebug("Dictionary item {dictionaryItemId} with {culture} culture, ingest avoided by '{guard}'.", dictionaryItem.Id, culture, blockingGuard.GetType().Name);
             return false;
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedGuardService.cs
@@ -1,0 +1,49 @@
+using System.Linq;
+using Enterspeed.Source.UmbracoCms.V9.Guards;
+using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Services
+{
+    public class EnterspeedGuardService : IEnterspeedGuardService
+    {
+        private readonly ILogger<EnterspeedGuardService> _logger;
+        private readonly EnterspeedContentHandlingGuardCollection _contentGuards;
+        private readonly EnterspeedDictionaryItemHandlingGuardCollection _dictionaryItemGuards;
+
+        public EnterspeedGuardService(
+            EnterspeedContentHandlingGuardCollection contentGuards,
+            EnterspeedDictionaryItemHandlingGuardCollection dictionaryItemGuards, 
+            ILogger<EnterspeedGuardService> logger)
+        {
+            _contentGuards = contentGuards;
+            _dictionaryItemGuards = dictionaryItemGuards;
+            _logger = logger;
+        }
+
+        public bool CanPublish(IPublishedContent content, string culture)
+        {
+            var blockingGuard = _contentGuards.FirstOrDefault(guard => !guard.CanPublish(content, culture));
+            if (blockingGuard == null)
+            {
+                return true;
+            }
+            
+            _logger.LogDebug("Content {contentId} with {culture} culture, publishing avoided by '{guard}'.", content.Id, culture, blockingGuard.GetType().Name);
+            return false;
+        }
+
+        public bool CanPublish(IDictionaryItem dictionaryItem, string culture)
+        {
+            var blockingGuard = _dictionaryItemGuards.FirstOrDefault(guard => !guard.CanPublish(dictionaryItem, culture));
+            if (blockingGuard == null)
+            {
+                return true;
+            }
+            
+            _logger.LogDebug("Dictionary item {dictionaryItemId} with {culture} culture, publishing avoided by '{guard}'.", dictionaryItem.Id, culture, blockingGuard.GetType().Name);
+            return false;
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/IEnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/IEnterspeedGuardService.cs
@@ -5,7 +5,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
 {
     public interface IEnterspeedGuardService
     {
-        bool CanPublish(IPublishedContent content, string culture);
-        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+        bool CanIngest(IPublishedContent content, string culture);
+        bool CanIngest(IDictionaryItem dictionaryItem, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/IEnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/IEnterspeedGuardService.cs
@@ -1,0 +1,11 @@
+using Umbraco.Cms.Core.Models;
+using Umbraco.Cms.Core.Models.PublishedContent;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Services
+{
+    public interface IEnterspeedGuardService
+    {
+        bool CanPublish(IPublishedContent content, string culture);
+        bool CanPublish(IDictionaryItem dictionaryItem, string culture);
+    }
+}


### PR DESCRIPTION
For Umbraco v8 and v9, we want to be able to provide guards to validate content/dictionary item before proceeding with the job that sends it towards Ingest API.

By default, we provide a content guard, for ensuring a culture-specific URL is available.