### PR TITLE
Add extension method for adjusted url retrieval

### DIFF
--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -106,11 +106,13 @@ stages:
 
           # Pack NuGet
           - task: NuGetCommand@2
+            env:
+              PACKAGE_VERSION: $(semVersion)
             inputs:
               command: 'pack'
               packagesToPack: '**/*.nuspec'
               versioningScheme: byEnvVar
-              versionEnvVar: semVersion
+              versionEnvVar: PACKAGE_VERSION
               includeSymbols: false
 
           # Publish artifacts

--- a/azure-pipelines.yml
+++ b/azure-pipelines.yml
@@ -38,6 +38,13 @@ variables:
     semVersionRev: $[counter(variables.semVersionBase, 0)]
     semVersion: $[format('{0}.{1}', variables.semVersionBase, variables.semVersionRev)]
     buildName: $[format('Pull Request - {0}', variables.semVersion)]
+  ${{ if startsWith(variables['Build.SourceBranch'], 'refs/heads/bugfix/') }}:
+    # Versioning: 1.0.0-bugfix.branch.123
+    releaseOnNuget: false
+    semVersionBase: $[format('{0}-bugfix.{1}', variables.version, variables['Build.SourceBranchName'])]
+    semVersionRev: $[counter(variables.semVersionBase, 0)]
+    semVersion: $[format('{0}.{1}', variables.semVersionBase, variables.semVersionRev)]
+    buildName: $[format('Bugfix - {0}', variables.semVersion)]
 
 name: $(BuildID) - $(buildName)
 
@@ -106,13 +113,11 @@ stages:
 
           # Pack NuGet
           - task: NuGetCommand@2
-            env:
-              PACKAGE_VERSION: $(semVersion)
             inputs:
               command: 'pack'
               packagesToPack: '**/*.nuspec'
               versioningScheme: byEnvVar
-              versionEnvVar: PACKAGE_VERSION
+              versionEnvVar: semVersion
               includeSymbols: false
 
           # Publish artifacts

--- a/src/Enterspeed.Source.UmbracoCms.V9/Extensions/PublishedContentExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Extensions/PublishedContentExtensions.cs
@@ -1,4 +1,5 @@
 ﻿using System.Globalization;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
@@ -6,7 +7,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Extensions
 {
     public static class PublishedContentExtensions
     {
-        public static string GetUrl(this IPublishedContent content, string culture = null, UrlMode mode = UrlMode.Default)
+        public static string GetUrl(this IPublishedContent content, ILogger logger, string culture = null, UrlMode mode = UrlMode.Default)
         {
             if (string.IsNullOrWhiteSpace(culture))
             {
@@ -19,8 +20,9 @@ namespace Enterspeed.Source.UmbracoCms.V9.Extensions
                 var normalizedCultureName = CultureInfo.GetCultureInfo(culture).Name;
                 return content.Url(normalizedCultureName, mode);
             }
-            catch (CultureNotFoundException)
+            catch (CultureNotFoundException exception)
             {
+                logger?.LogError(exception, "Error to get culture info for {contentId} {culture}", content.Id, culture);
             }
 
             return content.Url(culture, mode);

--- a/src/Enterspeed.Source.UmbracoCms.V9/Extensions/PublishedContentExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Extensions/PublishedContentExtensions.cs
@@ -1,0 +1,29 @@
+﻿using System.Globalization;
+using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Extensions;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Extensions
+{
+    public static class PublishedContentExtensions
+    {
+        public static string GetUrl(this IPublishedContent content, string culture = null, UrlMode mode = UrlMode.Default)
+        {
+            if (string.IsNullOrWhiteSpace(culture))
+            {
+                return content.Url(mode: mode);
+            }
+
+            try
+            {
+                // We want to make sure they are correctly cased, as 'en-us' will become 'en-US'
+                var normalizedCultureName = CultureInfo.GetCultureInfo(culture).Name;
+                return content.Url(normalizedCultureName, mode);
+            }
+            catch (CultureNotFoundException)
+            {
+            }
+
+            return content.Url(culture, mode);
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
@@ -1,3 +1,4 @@
+using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
@@ -12,7 +13,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
                 return true;
             }
 
-            var url = content.Url(culture);
+            var url = content.GetUrl(culture);
             return !string.IsNullOrWhiteSpace(url) && !url.Equals("#");
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
@@ -22,7 +22,13 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
             }
 
             var url = content.GetUrl(_logger, culture);
-            return !string.IsNullOrWhiteSpace(url) && !url.Equals("#");
+            if (!string.IsNullOrWhiteSpace(url) && !url.Equals("#"))
+            {
+                return true;
+            }
+            
+            _logger.LogInformation("Content '{contentId}' does not have available url '{contentUrl}' for '{culture}' culture.", content.Id, url, culture);
+            return false;
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Guards/ContentCultureUrlRequiredGuard.cs
@@ -1,4 +1,5 @@
 using Enterspeed.Source.UmbracoCms.V9.Extensions;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
@@ -6,6 +7,13 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
 {
     public class ContentCultureUrlRequiredGuard : IEnterspeedContentHandlingGuard
     {
+        private ILogger<ContentCultureUrlRequiredGuard> _logger;
+
+        public ContentCultureUrlRequiredGuard(ILogger<ContentCultureUrlRequiredGuard> logger)
+        {
+            _logger = logger;
+        }
+
         public bool CanIngest(IPublishedContent content, string culture)
         {
             if (string.IsNullOrWhiteSpace(culture))
@@ -13,7 +21,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Guards
                 return true;
             }
 
-            var url = content.GetUrl(culture);
+            var url = content.GetUrl(_logger, culture);
             return !string.IsNullOrWhiteSpace(url) && !url.Equals("#");
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Handlers/EnterspeedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Handlers/EnterspeedJobHandler.cs
@@ -151,7 +151,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Handlers
                                     var redirects = _redirectsService.GetRedirects(content.Key, culture);
                                     umbracoData = new UmbracoContentEntity(
                                         content, _enterspeedPropertyService, _entityIdentityService, redirects,
-                                        culture);
+                                        _logger, culture);
                                 }
                                 catch (Exception e)
                                 {

--- a/src/Enterspeed.Source.UmbracoCms.V9/Models/UmbracoContentEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Models/UmbracoContentEntity.cs
@@ -3,6 +3,7 @@ using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Enterspeed.Source.UmbracoCms.V9.Services;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
@@ -12,6 +13,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Models
     {
         private readonly IPublishedContent _content;
         private readonly IEntityIdentityService _entityIdentityService;
+        private readonly ILogger _logger;
         private readonly string _culture;
 
         public UmbracoContentEntity(
@@ -19,18 +21,20 @@ namespace Enterspeed.Source.UmbracoCms.V9.Models
             IEnterspeedPropertyService propertyService,
             IEntityIdentityService entityIdentityService,
             string[] redirects,
+            ILogger logger,
             string culture = null)
         {
             _content = content;
             _culture = culture;
             _entityIdentityService = entityIdentityService;
+            _logger = logger;
             Redirects = redirects;
             Properties = propertyService.GetProperties(_content, _culture);
         }
 
         public string Id => _entityIdentityService.GetId(_content, _culture);
         public string Type => _content.ContentType.Alias;
-        public string Url => _culture != null ? _content.GetUrl(_culture) : _content.GetUrl(null, UrlMode.Absolute);
+        public string Url => _culture != null ? _content.GetUrl(_logger, _culture) : _content.GetUrl(_logger, null, UrlMode.Absolute);
         public string[] Redirects { get; }
         public string ParentId => _entityIdentityService.GetId(_content.Parent, _culture);
         public IDictionary<string, IEnterspeedProperty> Properties { get; }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Models/UmbracoContentEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Models/UmbracoContentEntity.cs
@@ -1,6 +1,7 @@
 ﻿using System.Collections.Generic;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
+using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Enterspeed.Source.UmbracoCms.V9.Services;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -29,7 +30,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Models
 
         public string Id => _entityIdentityService.GetId(_content, _culture);
         public string Type => _content.ContentType.Alias;
-        public string Url => _culture != null ? _content.Url(_culture) : _content.Url(null, UrlMode.Absolute);
+        public string Url => _culture != null ? _content.GetUrl(_culture) : _content.GetUrl(null, UrlMode.Absolute);
         public string[] Redirects { get; }
         public string ParentId => _entityIdentityService.GetId(_content.Parent, _culture);
         public IDictionary<string, IEnterspeedProperty> Properties { get; }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Enterspeed.Source.UmbracoCms.V9.Services;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
@@ -17,7 +18,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Providers
 
         public string GetUrl(IPublishedContent media)
         {
-            var relativeUrl = media.Url(null, UrlMode.Relative);
+            var relativeUrl = media.GetUrl(null, UrlMode.Relative);
 
             var enterspeedMediaDomain = _enterspeedConfigurationService.GetConfiguration().MediaDomain;
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))

--- a/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
@@ -1,6 +1,7 @@
 ﻿using System;
 using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Enterspeed.Source.UmbracoCms.V9.Services;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Extensions;
 
@@ -9,16 +10,19 @@ namespace Enterspeed.Source.UmbracoCms.V9.Providers
     public class UmbracoMediaUrlProvider : IUmbracoMediaUrlProvider
     {
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
+        private readonly ILogger<UmbracoMediaUrlProvider> _logger;
 
         public UmbracoMediaUrlProvider(
-            IEnterspeedConfigurationService enterspeedConfigurationService)
+            IEnterspeedConfigurationService enterspeedConfigurationService,
+            ILogger<UmbracoMediaUrlProvider> logger)
         {
             _enterspeedConfigurationService = enterspeedConfigurationService;
+            _logger = logger;
         }
 
         public string GetUrl(IPublishedContent media)
         {
-            var relativeUrl = media.GetUrl(null, UrlMode.Relative);
+            var relativeUrl = media.GetUrl(_logger, null, UrlMode.Relative);
 
             var enterspeedMediaDomain = _enterspeedConfigurationService.GetConfiguration().MediaDomain;
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
@@ -2,6 +2,7 @@
 using System.Collections.Generic;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V9.Extensions;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
 using Umbraco.Cms.Core.PropertyEditors;
 using Umbraco.Extensions;
@@ -11,10 +12,14 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
     public class DefaultMultiNodeTreePickerPropertyValueConverter : IEnterspeedPropertyValueConverter
     {
         private readonly IEntityIdentityService _entityIdentityService;
+        private readonly ILogger<DefaultMultiNodeTreePickerPropertyValueConverter> _logger;
 
-        public DefaultMultiNodeTreePickerPropertyValueConverter(IEntityIdentityService entityIdentityService)
+        public DefaultMultiNodeTreePickerPropertyValueConverter(
+            IEntityIdentityService entityIdentityService,
+            ILogger<DefaultMultiNodeTreePickerPropertyValueConverter> logger)
         {
             _entityIdentityService = entityIdentityService;
+            _logger = logger;
         }
 
         public bool IsConverter(IPublishedPropertyType propertyType)
@@ -84,7 +89,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
             {
                 { "id", new StringEnterspeedProperty(id) },
                 { "name", new StringEnterspeedProperty(node.Name) },
-                { "url", new StringEnterspeedProperty(node.GetUrl(culture, UrlMode.Absolute)) }
+                { "url", new StringEnterspeedProperty(node.GetUrl(_logger, culture, UrlMode.Absolute)) }
             };
 
             return new ObjectEnterspeedProperty(properties);

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
@@ -84,7 +84,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
             {
                 { "id", new StringEnterspeedProperty(id) },
                 { "name", new StringEnterspeedProperty(node.Name) },
-                { "url", new StringEnterspeedProperty(node.Url(culture, UrlMode.Absolute)) }
+                { "url", new StringEnterspeedProperty(node.GetUrl(culture, UrlMode.Absolute)) }
             };
 
             return new ObjectEnterspeedProperty(properties);

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedGuardService.cs
@@ -30,7 +30,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
                 return true;
             }
             
-            _logger.LogDebug("Content {contentId} with {culture} culture, ingest avoided by '{guard}'.", content.Id, culture, blockingGuard.GetType().Name);
+            _logger.LogInformation("Content {contentId} with {culture} culture, ingest avoided by '{guard}'.", content.Id, culture, blockingGuard.GetType().Name);
             return false;
         }
 


### PR DESCRIPTION
There is a difference in how `IPublishedContent.Url(culture)` works in Umbraco 9.0 and 9.1.

9.0 didn't care if culture we pass on is lowercased, camel cased, or whatever, but 9.1 is more strict about it, it must be original value for culture name.

The reason for creating a new extension method is to touch as little usage places directly as possible since there is some confusion from Umbraco part:
- Umbraco context get default culture returns in the format of '**en-US**'
- Published Content cultures array contains lowercased values as - '**en-us**'
- PublishedContent `Url(culture)` expects to pass '**en-US**' format instead of '**en-us**'

Besides all these conditions mentioned, during ingest to Enterspeed all culture references must be lowercased, since it's used in different properties, origin ids, etc, messing which up, might lead to source entity duplicates and broken references.

My idea was, to parse string to culture info, get its proper system name - 'en-us' becomes 'en-US'.