### PR TITLE
Combine relative path urls

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
@@ -252,6 +252,7 @@
     <Compile Include="EventHandlers\ContentEventHandler.cs" />
     <Compile Include="EventHandlers\DictionaryEventHandler.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="Handlers\EnterspeedJobHandler.cs" />
     <Compile Include="Models\Api\ApiResponse.cs" />
     <Compile Include="Models\Api\SeedResponse.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V7/Extensions/UriExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Extensions/UriExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Enterspeed.Source.UmbracoCms.V7.Extensions
+{
+    public static class UriExtensions
+    {
+        public static Uri AppendPath(this Uri uri, string path)
+        {
+            return new Uri(uri, uri.AbsolutePath.TrimEnd('/') + '/' + path.TrimStart('/'));
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Providers/UmbracoMediaUrlProvider.cs
@@ -1,5 +1,6 @@
 ﻿using System;
 using Enterspeed.Source.UmbracoCms.V7.Contexts;
+using Enterspeed.Source.UmbracoCms.V7.Extensions;
 using Enterspeed.Source.UmbracoCms.V7.Services;
 using Umbraco.Core.Models;
 using Umbraco.Web;
@@ -41,28 +42,10 @@ namespace Enterspeed.Source.UmbracoCms.V7.Providers
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))
             {
                 var mediaDomainUrl = new Uri(enterspeedMediaDomain);
-                return new Uri(Combine(mediaDomainUrl.ToString(), url)).ToString();
+                return mediaDomainUrl.AppendPath(url).ToString();
             }
 
             return url;
-        }
-
-        /// <summary>
-        /// Combines the url base and the relative url into one, consolidating the '/' between them.
-        /// </summary>
-        /// <param name="baseUrl">Base url that will be combined.</param>
-        /// <param name="relativeUrl">The relative path to combine.</param>
-        /// <returns>The merged url.</returns>
-        internal string Combine(string baseUrl, string relativeUrl)
-        {
-            if (string.IsNullOrWhiteSpace(relativeUrl))
-            {
-                return baseUrl;
-            }
-
-            baseUrl = baseUrl.TrimEnd('/');
-            relativeUrl = relativeUrl.TrimStart('/');
-            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Providers/UmbracoMediaUrlProvider.cs
@@ -41,10 +41,28 @@ namespace Enterspeed.Source.UmbracoCms.V7.Providers
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))
             {
                 var mediaDomainUrl = new Uri(enterspeedMediaDomain);
-                return new Uri(mediaDomainUrl, url).ToString();
+                return new Uri(Combine(mediaDomainUrl.ToString(), url)).ToString();
             }
 
             return url;
+        }
+
+        /// <summary>
+        /// Combines the url base and the relative url into one, consolidating the '/' between them.
+        /// </summary>
+        /// <param name="baseUrl">Base url that will be combined.</param>
+        /// <param name="relativeUrl">The relative path to combine.</param>
+        /// <returns>The merged url.</returns>
+        internal string Combine(string baseUrl, string relativeUrl)
+        {
+            if (string.IsNullOrWhiteSpace(relativeUrl))
+            {
+                return baseUrl;
+            }
+
+            baseUrl = baseUrl.TrimEnd('/');
+            relativeUrl = relativeUrl.TrimStart('/');
+            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -294,6 +294,7 @@
     <Compile Include="Data\Schemas\EnterspeedJobSchema.cs" />
     <Compile Include="Extensions\PropertyExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
+    <Compile Include="Extensions\UriExtensions.cs" />
     <Compile Include="Guards\ContentCultureUrlRequiredGuard.cs" />
     <Compile Include="Guards\EnterspeedContentHandlingGuardCollection.cs" />
     <Compile Include="Guards\EnterspeedContentHandlingGuardCollectionBuilder.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Extensions/UriExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Extensions/UriExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Extensions
+{
+    public static class UriExtensions
+    {
+        public static Uri AppendPath(this Uri uri, string path)
+        {
+            return new Uri(uri, uri.AbsolutePath.TrimEnd('/') + '/' + path.TrimStart('/'));
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Providers/UmbracoMediaUrlProvider.cs
@@ -23,10 +23,28 @@ namespace Enterspeed.Source.UmbracoCms.V8.Providers
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))
             {
                 var mediaDomainUrl = new Uri(enterspeedMediaDomain);
-                return new Uri(mediaDomainUrl, relativeUrl).ToString();
+                return new Uri(Combine(mediaDomainUrl.ToString(), relativeUrl)).ToString();
             }
 
             return relativeUrl;
+        }
+
+        /// <summary>
+        /// Combines the url base and the relative url into one, consolidating the '/' between them.
+        /// </summary>
+        /// <param name="baseUrl">Base url that will be combined.</param>
+        /// <param name="relativeUrl">The relative path to combine.</param>
+        /// <returns>The merged url.</returns>
+        internal string Combine(string baseUrl, string relativeUrl)
+        {
+            if (string.IsNullOrWhiteSpace(relativeUrl))
+            {
+                return baseUrl;
+            }
+
+            baseUrl = baseUrl.TrimEnd('/');
+            relativeUrl = relativeUrl.TrimStart('/');
+            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Providers/UmbracoMediaUrlProvider.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using Enterspeed.Source.UmbracoCms.V8.Extensions;
 using Enterspeed.Source.UmbracoCms.V8.Services;
 using Umbraco.Core.Models.PublishedContent;
 using Umbraco.Web;
@@ -23,28 +24,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Providers
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))
             {
                 var mediaDomainUrl = new Uri(enterspeedMediaDomain);
-                return new Uri(Combine(mediaDomainUrl.ToString(), relativeUrl)).ToString();
+                return mediaDomainUrl.AppendPath(relativeUrl).ToString();
             }
 
             return relativeUrl;
-        }
-
-        /// <summary>
-        /// Combines the url base and the relative url into one, consolidating the '/' between them.
-        /// </summary>
-        /// <param name="baseUrl">Base url that will be combined.</param>
-        /// <param name="relativeUrl">The relative path to combine.</param>
-        /// <returns>The merged url.</returns>
-        internal string Combine(string baseUrl, string relativeUrl)
-        {
-            if (string.IsNullOrWhiteSpace(relativeUrl))
-            {
-                return baseUrl;
-            }
-
-            baseUrl = baseUrl.TrimEnd('/');
-            relativeUrl = relativeUrl.TrimStart('/');
-            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Extensions/UriExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Extensions/UriExtensions.cs
@@ -1,0 +1,12 @@
+using System;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Extensions
+{
+    public static class UriExtensions
+    {
+        public static Uri AppendPath(this Uri uri, string path)
+        {
+            return new Uri(uri, uri.AbsolutePath.TrimEnd('/') + '/' + path.TrimStart('/'));	
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
@@ -3,7 +3,6 @@ using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Enterspeed.Source.UmbracoCms.V9.Services;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core.Models.PublishedContent;
-using Umbraco.Extensions;
 
 namespace Enterspeed.Source.UmbracoCms.V9.Providers
 {
@@ -28,10 +27,28 @@ namespace Enterspeed.Source.UmbracoCms.V9.Providers
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))
             {
                 var mediaDomainUrl = new Uri(enterspeedMediaDomain);
-                return new Uri(mediaDomainUrl, relativeUrl).ToString();
+                return new Uri(Combine(mediaDomainUrl.ToString(), relativeUrl)).ToString();
             }
 
             return relativeUrl;
+        }
+        
+        /// <summary>
+        /// Combines the url base and the relative url into one, consolidating the '/' between them.
+        /// </summary>
+        /// <param name="baseUrl">Base url that will be combined.</param>
+        /// <param name="relativeUrl">The relative path to combine.</param>
+        /// <returns>The merged url.</returns>
+        internal string Combine(string baseUrl, string relativeUrl)
+        {
+            if (string.IsNullOrWhiteSpace(relativeUrl))
+            {
+                return baseUrl;
+            }
+
+            baseUrl = baseUrl.TrimEnd('/');
+            relativeUrl = relativeUrl.TrimStart('/');
+            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Providers/UmbracoMediaUrlProvider.cs
@@ -27,28 +27,10 @@ namespace Enterspeed.Source.UmbracoCms.V9.Providers
             if (!string.IsNullOrWhiteSpace(enterspeedMediaDomain))
             {
                 var mediaDomainUrl = new Uri(enterspeedMediaDomain);
-                return new Uri(Combine(mediaDomainUrl.ToString(), relativeUrl)).ToString();
+                return mediaDomainUrl.AppendPath(relativeUrl).ToString();
             }
 
             return relativeUrl;
-        }
-        
-        /// <summary>
-        /// Combines the url base and the relative url into one, consolidating the '/' between them.
-        /// </summary>
-        /// <param name="baseUrl">Base url that will be combined.</param>
-        /// <param name="relativeUrl">The relative path to combine.</param>
-        /// <returns>The merged url.</returns>
-        internal string Combine(string baseUrl, string relativeUrl)
-        {
-            if (string.IsNullOrWhiteSpace(relativeUrl))
-            {
-                return baseUrl;
-            }
-
-            baseUrl = baseUrl.TrimEnd('/');
-            relativeUrl = relativeUrl.TrimStart('/');
-            return $"{baseUrl}/{relativeUrl}";
         }
     }
 }


### PR DESCRIPTION
The current solution doesn't handle relative paths correctly.

### Example:
Media domain: `https://blob.com/container`
Media relative url in Umbraco: `/media/123.png`

Outcome: `https://blob.com/media/123.png`
Expected outcome: `https://blob.com/container/media/123.png`
