### PR TITLE
Check if content picker content is available

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultContentPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultContentPickerPropertyValueConverter.cs
@@ -21,6 +21,11 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
 
         public IEnterspeedProperty Convert(IPublishedProperty property, string culture)
         {
+            if (property.GetSourceValue(culture) == null)
+            {
+                return null;
+            }
+
             var value = property.GetValue<IPublishedContent>(culture);
             var contentId = _entityIdentityService.GetId(value, culture);
             return new StringEnterspeedProperty(property.Alias, contentId);


### PR DESCRIPTION
When referencing unpublished content, it stores UDI value of it, but fails to cast to IPublishedContent, throwing an exception.