### PR TITLE
Feature/enterspeed media type

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
@@ -259,6 +259,7 @@
     <Compile Include="Extensions\ContentBaseExtensions.cs" />
     <Compile Include="Extensions\ContentExtensions.cs" />
     <Compile Include="Extensions\EnterspeedConfigurationExtensions.cs" />
+    <Compile Include="Extensions\MediaExtensions.cs" />
     <Compile Include="Extensions\UrlStringExtensions.cs" />
     <Compile Include="Factories\EnterspeedJobFactory.cs" />
     <Compile Include="Models\UmbFile.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
@@ -261,6 +261,8 @@
     <Compile Include="Extensions\EnterspeedConfigurationExtensions.cs" />
     <Compile Include="Extensions\UrlStringExtensions.cs" />
     <Compile Include="Factories\EnterspeedJobFactory.cs" />
+    <Compile Include="Models\UmbFile.cs" />
+    <Compile Include="Models\UmbracoMediaEntity.cs" />
     <Compile Include="Models\UmbracoModels\PublishedPropertyBase.cs" />
     <Compile Include="Models\UmbracoModels\PublishedProperty.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
@@ -254,6 +254,7 @@
     <Compile Include="Data\Schemas\EnterspeedJobSchema.cs" />
     <Compile Include="EventHandlers\ConfigurationEventHandler.cs" />
     <Compile Include="EventHandlers\ContentEventHandler.cs" />
+    <Compile Include="EventHandlers\MediaEventHandler.cs" />
     <Compile Include="EventHandlers\DictionaryEventHandler.cs" />
     <Compile Include="Extensions\ContentBaseExtensions.cs" />
     <Compile Include="Extensions\ContentExtensions.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
@@ -8,6 +8,7 @@ using Umbraco.Core;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
+using Umbraco.Web;
 
 namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
 {
@@ -18,11 +19,101 @@ namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
         {
             MediaService.Saved += MediaService_Saved;
+            MediaService.Moved += MediaService_Moved;
+            MediaService.Trashed += MediaService_Trashed;
+        }
+
+        private static void MediaService_Trashed(IMediaService sender, MoveEventArgs<IMedia> e)
+        {
+            var isPublishConfigured = EnterspeedContext.Current.Services.ConfigurationService.IsPublishConfigured();
+
+            if (!isPublishConfigured)
+            {
+                return;
+            }
+
+            var entities = e.MoveInfoCollection.ToList();
+            var jobs = new List<EnterspeedJob>();
+
+            foreach (var mediaItem in entities.Select(ei => ei.Entity))
+            {
+                jobs.Add(EnterspeedJobFactory.GetDeleteJob(mediaItem, string.Empty, EnterspeedContentState.Publish));
+            }
+
+            EnqueueJobs(jobs);
+        }
+
+        private static void MediaService_Moved(IMediaService sender, MoveEventArgs<IMedia> e)
+        {
+            var isPublishConfigured = EnterspeedContext.Current.Services.ConfigurationService.IsPublishConfigured();
+
+            if (!isPublishConfigured)
+            {
+                return;
+            }
+
+            var entities = e.MoveInfoCollection.ToList();
+            var jobs = new List<EnterspeedJob>();
+
+            foreach (var mediaItem in entities.Select(ei => ei.Entity))
+            {
+                if (mediaItem.ContentType.Alias.Equals("Folder"))
+                {
+                    var mediaItems = ApplicationContext.Current.Services.MediaService.GetPagedDescendants(mediaItem.Id, 0, 99999, out long totalRecords).ToList();
+                    if (totalRecords > 0)
+                    {
+                        foreach (var item in mediaItems)
+                        {
+                            if (!item.ContentType.Alias.Equals("Folder"))
+                            {
+                                jobs.Add(EnterspeedJobFactory.GetPublishJob(item, string.Empty, EnterspeedContentState.Publish));
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    jobs.Add(EnterspeedJobFactory.GetPublishJob(mediaItem, string.Empty, EnterspeedContentState.Publish));
+                }
+            }
+
+            EnqueueJobs(jobs);
         }
 
         private static void MediaService_Saved(IMediaService sender, SaveEventArgs<IMedia> e)
         {
             var jobs = new List<EnterspeedJob>();
+            var isPublishConfigured = EnterspeedContext.Current.Services.ConfigurationService.IsPublishConfigured();
+
+            if (!isPublishConfigured)
+            {
+                return;
+            }
+
+            var entities = e.SavedEntities.ToList();
+
+            foreach (var mediaItem in entities)
+            {
+                if (mediaItem.ContentType.Alias.Equals("Folder"))
+                {
+                    var mediaItems = ApplicationContext.Current.Services.MediaService.GetPagedDescendants(mediaItem.Id, 0, 99999, out long totalRecords).ToList();
+                    if (totalRecords > 0)
+                    {
+                        foreach (var item in mediaItems)
+                        {
+                            if (!item.ContentType.Alias.Equals("Folder"))
+                            {
+                                jobs.Add(EnterspeedJobFactory.GetPublishJob(item, string.Empty, EnterspeedContentState.Publish));
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    jobs.Add(EnterspeedJobFactory.GetPublishJob(mediaItem, string.Empty, EnterspeedContentState.Publish));
+                }
+            }
+
             EnqueueJobs(jobs);
         }
 

--- a/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
+﻿using System.Collections.Generic;
 using System.Linq;
 using Enterspeed.Source.UmbracoCms.V7.Contexts;
 using Enterspeed.Source.UmbracoCms.V7.Data.Models;

--- a/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
@@ -1,0 +1,40 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using Enterspeed.Source.UmbracoCms.V7.Contexts;
+using Enterspeed.Source.UmbracoCms.V7.Data.Models;
+using Enterspeed.Source.UmbracoCms.V7.Factories;
+using Umbraco.Core;
+using Umbraco.Core.Events;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
+{
+    public class MediaEventHandler : ApplicationEventHandler
+    {
+        private static readonly EnterspeedJobFactory EnterspeedJobFactory = EnterspeedContext.Current.Services.JobFactory;
+
+        protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
+        {
+            MediaService.Saved += MediaService_Saved;
+        }
+
+        private static void MediaService_Saved(IMediaService sender, SaveEventArgs<IMedia> e)
+        {
+            var jobs = new List<EnterspeedJob>();
+            EnqueueJobs(jobs);
+        }
+
+        private static void EnqueueJobs(List<EnterspeedJob> jobs)
+        {
+            if (!jobs.Any())
+            {
+                return;
+            }
+
+            EnterspeedContext.Current.Repositories.JobRepository.Save(jobs);
+            EnterspeedContext.Current.Handlers.JobHandler.HandleJobs(jobs);
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/EventHandlers/MediaEventHandler.cs
@@ -7,12 +7,12 @@ using Umbraco.Core;
 using Umbraco.Core.Events;
 using Umbraco.Core.Models;
 using Umbraco.Core.Services;
-using Umbraco.Web;
 
 namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
 {
     public class MediaEventHandler : ApplicationEventHandler
     {
+        private const int IndexPageSize = 9999;
         private static readonly EnterspeedJobFactory EnterspeedJobFactory = EnterspeedContext.Current.Services.JobFactory;
 
         protected override void ApplicationStarted(UmbracoApplicationBase umbracoApplication, ApplicationContext applicationContext)
@@ -51,37 +51,14 @@ namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
                 return;
             }
 
-            var entities = e.MoveInfoCollection.ToList();
-            var jobs = new List<EnterspeedJob>();
-
-            foreach (var mediaItem in entities.Select(ei => ei.Entity))
-            {
-                if (mediaItem.ContentType.Alias.Equals("Folder"))
-                {
-                    var mediaItems = ApplicationContext.Current.Services.MediaService.GetPagedDescendants(mediaItem.Id, 0, 99999, out long totalRecords).ToList();
-                    if (totalRecords > 0)
-                    {
-                        foreach (var item in mediaItems)
-                        {
-                            if (!item.ContentType.Alias.Equals("Folder"))
-                            {
-                                jobs.Add(EnterspeedJobFactory.GetPublishJob(item, string.Empty, EnterspeedContentState.Publish));
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    jobs.Add(EnterspeedJobFactory.GetPublishJob(mediaItem, string.Empty, EnterspeedContentState.Publish));
-                }
-            }
+            var entities = e.MoveInfoCollection?.Select(ei => ei.Entity).ToList();
+            var jobs = MapJobs(entities);
 
             EnqueueJobs(jobs);
         }
 
         private static void MediaService_Saved(IMediaService sender, SaveEventArgs<IMedia> e)
         {
-            var jobs = new List<EnterspeedJob>();
             var isPublishConfigured = EnterspeedContext.Current.Services.ConfigurationService.IsPublishConfigured();
 
             if (!isPublishConfigured)
@@ -90,28 +67,7 @@ namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
             }
 
             var entities = e.SavedEntities.ToList();
-
-            foreach (var mediaItem in entities)
-            {
-                if (mediaItem.ContentType.Alias.Equals("Folder"))
-                {
-                    var mediaItems = ApplicationContext.Current.Services.MediaService.GetPagedDescendants(mediaItem.Id, 0, 99999, out long totalRecords).ToList();
-                    if (totalRecords > 0)
-                    {
-                        foreach (var item in mediaItems)
-                        {
-                            if (!item.ContentType.Alias.Equals("Folder"))
-                            {
-                                jobs.Add(EnterspeedJobFactory.GetPublishJob(item, string.Empty, EnterspeedContentState.Publish));
-                            }
-                        }
-                    }
-                }
-                else
-                {
-                    jobs.Add(EnterspeedJobFactory.GetPublishJob(mediaItem, string.Empty, EnterspeedContentState.Publish));
-                }
-            }
+            var jobs = MapJobs(entities);
 
             EnqueueJobs(jobs);
         }
@@ -125,6 +81,35 @@ namespace Enterspeed.Source.UmbracoCms.V7.EventHandlers
 
             EnterspeedContext.Current.Repositories.JobRepository.Save(jobs);
             EnterspeedContext.Current.Handlers.JobHandler.HandleJobs(jobs);
+        }
+
+        private static List<EnterspeedJob> MapJobs(List<IMedia> entities)
+        {
+            var jobs = new List<EnterspeedJob>();
+
+            foreach (var mediaItem in entities)
+            {
+                if (mediaItem.ContentType.Alias.Equals("Folder"))
+                {
+                    var mediaItems = ApplicationContext.Current.Services.MediaService.GetPagedDescendants(mediaItem.Id, 0, IndexPageSize, out long totalRecords).ToList();
+                    if (totalRecords > 0)
+                    {
+                        foreach (var item in mediaItems)
+                        {
+                            if (!item.ContentType.Alias.Equals("Folder"))
+                            {
+                                jobs.Add(EnterspeedJobFactory.GetPublishJob(item, string.Empty, EnterspeedContentState.Publish));
+                            }
+                        }
+                    }
+                }
+                else
+                {
+                    jobs.Add(EnterspeedJobFactory.GetPublishJob(mediaItem, string.Empty, EnterspeedContentState.Publish));
+                }
+            }
+
+            return jobs;
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Extensions/MediaExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Extensions/MediaExtensions.cs
@@ -10,24 +10,16 @@ namespace Enterspeed.Source.UmbracoCms.V7.Extensions
     {
         public static string GetMediaUrl(this IMedia media, EnterspeedUmbracoConfiguration configuration)
         {
-            string url = string.Empty;
             var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
             if (umbracoFile != null && umbracoFile.Contains("src"))
             {
                 var umbFile = JsonConvert.DeserializeObject<UmbFile>(umbracoFile);
-                if (umbFile != null)
-                {
-                    url = configuration.MediaDomain + umbFile.Src;
-                }
-            }
-            else
-            {
-                // Should be a complex type, but is sometimes only a string. I don't know why.
-                // Might be some behaviour in Umbraco
-                url = umbracoFile;
+                return umbFile != null ? configuration.MediaDomain + umbFile.Src : string.Empty;
             }
 
-            return url;
+            // Should be a complex type, but is sometimes only a string. I don't know why.
+            // Might be some behaviour in Umbraco
+            return umbracoFile;
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Extensions/MediaExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Extensions/MediaExtensions.cs
@@ -1,0 +1,33 @@
+﻿using Enterspeed.Source.UmbracoCms.V7.Models;
+using Enterspeed.Source.UmbracoCms.V7.Models.Configuration;
+using Newtonsoft.Json;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+namespace Enterspeed.Source.UmbracoCms.V7.Extensions
+{
+    public static class MediaExtensions
+    {
+        public static string GetMediaUrl(this IMedia media, EnterspeedUmbracoConfiguration configuration)
+        {
+            string url = string.Empty;
+            var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
+            if (umbracoFile != null && umbracoFile.Contains("src"))
+            {
+                var umbFile = JsonConvert.DeserializeObject<UmbFile>(umbracoFile);
+                if (umbFile != null)
+                {
+                    url = configuration.MediaDomain + umbFile.Src;
+                }
+            }
+            else
+            {
+                // Should be a complex type, but is sometimes only a string. I don't know why.
+                // Might be some behaviour in Umbraco
+                url = umbracoFile;
+            }
+
+            return url;
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/Factories/EnterspeedJobFactory.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Factories/EnterspeedJobFactory.cs
@@ -88,6 +88,38 @@ namespace Enterspeed.Source.UmbracoCms.V7.Factories
             };
         }
 
+        public EnterspeedJob GetPublishJob(IMedia media, string culture, EnterspeedContentState state)
+        {
+            var now = DateTime.UtcNow;
+            return new EnterspeedJob
+            {
+                EntityId = media.Id.ToString(),
+                EntityType = EnterspeedJobEntityType.Media,
+                Culture = culture,
+                JobType = EnterspeedJobType.Publish,
+                State = EnterspeedJobState.Pending,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ContentState = state,
+            };
+        }
+
+        public EnterspeedJob GetDeleteJob(IMedia media, string culture, EnterspeedContentState state)
+        {
+            var now = DateTime.UtcNow;
+            return new EnterspeedJob
+            {
+                EntityId = media.Id.ToString(),
+                EntityType = EnterspeedJobEntityType.Media,
+                Culture = culture,
+                JobType = EnterspeedJobType.Delete,
+                State = EnterspeedJobState.Pending,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ContentState = state,
+            };
+        }
+
         public EnterspeedJob GetFailedJob(EnterspeedJob job, string exception)
         {
             return new EnterspeedJob

--- a/src/Enterspeed.Source.UmbracoCms.V7/Handlers/EnterspeedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Handlers/EnterspeedJobHandler.cs
@@ -307,7 +307,6 @@ namespace Enterspeed.Source.UmbracoCms.V7.Handlers
                                 var exception = $"Failed deleting entity ({newestPreviewJob.EntityId}/{newestPreviewJob.Culture}). Message: {deleteResponse.Message}";
                                 failedJobs.Add(_enterspeedJobFactory.GetFailedJob(newestPreviewJob, exception));
                                 LogHelper.Warn<EnterspeedJobHandler>(exception);
-                                continue;
                             }
                         }
                     }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Handlers/EnterspeedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Handlers/EnterspeedJobHandler.cs
@@ -172,6 +172,31 @@ namespace Enterspeed.Source.UmbracoCms.V7.Handlers
                                 continue;
                             }
                         }
+                        else if (newestPublishJob.EntityType == EnterspeedJobEntityType.Media)
+                        {
+                            var parsed = int.TryParse(newestPublishJob.EntityId, out var parsedId);
+                            var media = parsed ? context.Application.Services.MediaService.GetById(parsedId) : null;
+
+                            if (media == null)
+                            {
+                                var exception = $"Media with id {newestPublishJob.EntityId} not in database";
+                                failedJobs.Add(_enterspeedJobFactory.GetFailedJob(newestPublishJob, exception));
+                                LogHelper.Warn<EnterspeedJobHandler>(exception);
+                            }
+
+                            try
+                            {
+                                umbracoData = new UmbracoMediaEntity(media);
+                            }
+                            catch (Exception e)
+                            {
+                                // Create a new failed job
+                                var exception = $"Failed creating entity ({newestPublishJob.EntityId}). Message: {e.Message}. StackTrace: {e.StackTrace}";
+                                failedJobs.Add(_enterspeedJobFactory.GetFailedJob(newestPublishJob, exception));
+                                LogHelper.Warn<EnterspeedJobHandler>(exception);
+                                continue;
+                            }
+                        }
 
                         var ingestResponse = _enterspeedPublishIngestService.Save(umbracoData);
                         if (!ingestResponse.Success)
@@ -197,6 +222,10 @@ namespace Enterspeed.Source.UmbracoCms.V7.Handlers
                         else if (newestPublishJob.EntityType == EnterspeedJobEntityType.Dictionary)
                         {
                             id = _entityIdentityService.GetId(newestPublishJob.EntityId, newestPublishJob.Culture);
+                        }
+                        else if (newestPublishJob.EntityType == EnterspeedJobEntityType.Media)
+                        {
+                            id = _entityIdentityService.GetId(newestPublishJob.EntityId);
                         }
 
                         if (!string.IsNullOrWhiteSpace(id))
@@ -294,6 +323,10 @@ namespace Enterspeed.Source.UmbracoCms.V7.Handlers
                             id = _entityIdentityService.GetId(newestPreviewJob.EntityId);
                         }
                         else if (newestPreviewJob.EntityType == EnterspeedJobEntityType.Dictionary)
+                        {
+                            id = _entityIdentityService.GetId(newestPreviewJob.EntityId, newestPreviewJob.Culture);
+                        }
+                        else if (newestPreviewJob.EntityType == EnterspeedJobEntityType.Media)
                         {
                             id = _entityIdentityService.GetId(newestPreviewJob.EntityId, newestPreviewJob.Culture);
                         }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Models/Api/SeedResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Models/Api/SeedResponse.cs
@@ -5,5 +5,6 @@
         public int JobsAdded { get; set; }
         public int ContentCount { get; set; }
         public int DictionaryCount { get; set; }
+        public long MediaCount { get; set; }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Models/UmbFile.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Models/UmbFile.cs
@@ -1,0 +1,10 @@
+﻿using Newtonsoft.Json;
+
+namespace Enterspeed.Source.UmbracoCms.V7.Models
+{
+    internal class UmbFile
+    {
+        [JsonProperty("src")]
+        public string Src { get; set; }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Models/UmbracoMediaEntity.cs
@@ -1,0 +1,48 @@
+﻿using System.Collections.Generic;
+using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Models.Properties;
+using Enterspeed.Source.UmbracoCms.V7.Contexts;
+using Enterspeed.Source.UmbracoCms.V7.Services;
+using Newtonsoft.Json;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+
+namespace Enterspeed.Source.UmbracoCms.V7.Models
+{
+    public class UmbracoMediaEntity : IEnterspeedEntity
+    {
+        private readonly IMedia _media;
+        private readonly EntityIdentityService _entityIdentityService;
+
+        public UmbracoMediaEntity(IMedia media)
+        {
+            _media = media;
+            _entityIdentityService = EnterspeedContext.Current.Services.EntityIdentityService;
+
+            var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
+            if (umbracoFile.Contains("src"))
+            {
+                var umbFile = JsonConvert.DeserializeObject<UmbFile>(umbracoFile);
+                if (umbFile != null)
+                {
+                    Url = umbFile.Src;
+                }
+            }
+            else
+            {
+                // Should be a complex type, but is sometimes only a string. I don't know why.
+                // Might be some behaviour in Umbraco
+                Url = umbracoFile;
+            }
+
+            Properties = EnterspeedContext.Current.Services.PropertyService.GetProperties(_media);
+        }
+
+        public string Id => _entityIdentityService.GetId(_media);
+        public string Type => "umbMedia";
+        public string Url { get; set; }
+        public string[] Redirects => null;
+        public string ParentId => _entityIdentityService.GetId(_media.ParentId.ToString());
+        public IDictionary<string, IEnterspeedProperty> Properties { get; }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Models/UmbracoMediaEntity.cs
@@ -2,9 +2,8 @@
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V7.Contexts;
+using Enterspeed.Source.UmbracoCms.V7.Extensions;
 using Enterspeed.Source.UmbracoCms.V7.Services;
-using Newtonsoft.Json;
-using Umbraco.Core;
 using Umbraco.Core.Models;
 
 namespace Enterspeed.Source.UmbracoCms.V7.Models
@@ -19,22 +18,8 @@ namespace Enterspeed.Source.UmbracoCms.V7.Models
             _media = media;
             _entityIdentityService = EnterspeedContext.Current.Services.EntityIdentityService;
 
-            var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
-            if (umbracoFile.Contains("src"))
-            {
-                var umbFile = JsonConvert.DeserializeObject<UmbFile>(umbracoFile);
-                if (umbFile != null)
-                {
-                    Url = umbFile.Src;
-                }
-            }
-            else
-            {
-                // Should be a complex type, but is sometimes only a string. I don't know why.
-                // Might be some behaviour in Umbraco
-                Url = umbracoFile;
-            }
-
+            var configurationService = EnterspeedContext.Current.Services.ConfigurationService;
+            Url = media.GetMediaUrl(configurationService.GetConfiguration());
             Properties = EnterspeedContext.Current.Services.PropertyService.GetProperties(_media);
         }
 

--- a/src/Enterspeed.Source.UmbracoCms.V7/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Services/EnterspeedPropertyService.cs
@@ -84,6 +84,23 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services
             return output;
         }
 
+        public IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media)
+        {
+            var enterspeedProperties = new Dictionary<string, IEnterspeedProperty>
+            {
+                { "name", new StringEnterspeedProperty("name", media.Name) },
+                { "size", new StringEnterspeedProperty("size", media.GetValue<string>("umbracoBytes")) },
+                { "type", new StringEnterspeedProperty("type", media.GetValue<string>("umbracoExtension")) },
+                { "path", new StringEnterspeedProperty("path", media.Path) },
+                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "level", new NumberEnterspeedProperty("level", media.Level) },
+                { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
+            };
+
+            return enterspeedProperties;
+        }
+
         private IEnterspeedProperty CreateMetaData(IPublishedContent content)
         {
             var metaData = new Dictionary<string, IEnterspeedProperty>
@@ -111,6 +128,20 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services
 
             return ids
                 .Select(x => new StringEnterspeedProperty(null, _identityService.GetId(x)))
+                .ToArray();
+        }
+
+        private IEnterspeedProperty[] GetNodePath(IMedia media)
+        {
+            var ids = media.Path
+                .Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(int.Parse)
+                .ToList();
+
+            ids.Remove(-1);
+
+            return ids
+                .Select(x => new StringEnterspeedProperty(null, _identityService.GetId(media)))
                 .ToArray();
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Services/EntityIdentityService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Services/EntityIdentityService.cs
@@ -59,5 +59,15 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services
         {
             return $"{contentId}-{culture}";
         }
+
+        public string GetId(IMedia mediaItem)
+        {
+            if (mediaItem == null)
+            {
+                return null;
+            }
+
+            return GetId(mediaItem.Id.ToString());
+        }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/DataPropertyValueConverter/CompositionExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/DataPropertyValueConverter/CompositionExtensions.cs
@@ -22,6 +22,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components.DataPropertyValueConverter
             this Composition composition)
             => composition.WithCollectionBuilder<EnterspeedDictionaryItemHandlingGuardCollectionBuilder>();
 
+        public static EnterspeedMediaHandlingGuardCollectionBuilder EnterspeedMediaHandlingGuards(
+            this Composition composition)
+            => composition.WithCollectionBuilder<EnterspeedMediaHandlingGuardCollectionBuilder>();
+
         public static EnterspeedJobHandlerCollectionBuilder EnterspeedJobHandlers(this Composition composition)
             => composition.WithCollectionBuilder<EnterspeedJobHandlerCollectionBuilder>();
     }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
@@ -134,7 +134,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
 
                  // Media 
                  .Append<EnterspeedMediaPublishJobHandler>()
-                 .Append<EnterspeedMediaTrashingJobHandler>()
+                 .Append<EnterspeedMediaTrashedJobHandler>()
 
                  // Preview content
                  .Append<EnterspeedPreviewContentPublishJobHandler>()
@@ -158,7 +158,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
             composition.Components().Append<EnterspeedDictionaryItemDeletingEventHandler>();
 
             composition.Components().Append<EnterspeedMediaItemSavedEventHandler>();
-            composition.Components().Append<EnterspeedMediaItemDeletingEventHandler>();
+            composition.Components().Append<EnterspeedMediaTrashedEventHandler>();
 
             composition.Components().Append<EnterspeedJobsComponent>();
             composition.Components().Append<EnterspeedBackgroundTasksComponent>();

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
@@ -13,6 +13,7 @@ using Enterspeed.Source.UmbracoCms.V8.Extensions;
 using Enterspeed.Source.UmbracoCms.V8.Factories;
 using Enterspeed.Source.UmbracoCms.V8.Guards;
 using Enterspeed.Source.UmbracoCms.V8.Handlers;
+using Enterspeed.Source.UmbracoCms.V8.Handlers.Media;
 using Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent;
 using Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewDictionaries;
 using Enterspeed.Source.UmbracoCms.V8.Providers;
@@ -118,6 +119,9 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
             // Dictionary items handling guards
             composition.EnterspeedDictionaryItemHandlingGuards();
 
+            // Media handling guards
+            composition.EnterspeedMediaHandlingGuards();
+
             // Job handlers
             composition.EnterspeedJobHandlers()
                  // Content
@@ -127,6 +131,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
                  // Dictionaries
                  .Append<EnterspeedDictionaryItemPublishJobHandler>()
                  .Append<EnterspeedDictionaryItemDeleteJobHandler>()
+
+                 // Media 
+                 .Append<EnterspeedMediaPublishJobHandler>()
+                 .Append<EnterspeedMediaDeleteJobHandler>()
 
                  // Preview content
                  .Append<EnterspeedPreviewContentPublishJobHandler>()
@@ -148,6 +156,9 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
 
             composition.Components().Append<EnterspeedDictionaryItemSavedEventHandler>();
             composition.Components().Append<EnterspeedDictionaryItemDeletingEventHandler>();
+
+            composition.Components().Append<EnterspeedMediaItemSavedEventHandler>();
+            composition.Components().Append<EnterspeedMediaItemDeletingEventHandler>();
 
             composition.Components().Append<EnterspeedJobsComponent>();
             composition.Components().Append<EnterspeedBackgroundTasksComponent>();

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
@@ -159,6 +159,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
 
             composition.Components().Append<EnterspeedMediaItemSavedEventHandler>();
             composition.Components().Append<EnterspeedMediaTrashedEventHandler>();
+            composition.Components().Append<EnterspeedMediaMovedEventHandler>();
 
             composition.Components().Append<EnterspeedJobsComponent>();
             composition.Components().Append<EnterspeedBackgroundTasksComponent>();

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
@@ -134,7 +134,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
 
                  // Media 
                  .Append<EnterspeedMediaPublishJobHandler>()
-                 .Append<EnterspeedMediaDeleteJobHandler>()
+                 .Append<EnterspeedMediaTrashingJobHandler>()
 
                  // Preview content
                  .Append<EnterspeedPreviewContentPublishJobHandler>()

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -298,7 +298,9 @@
     <Compile Include="EventHandlers\EnterspeedContentPublishingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedContentTrashingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedContentUnpublishingEventHandler.cs" />
+    <Compile Include="EventHandlers\EnterspeedMediaItemDeletingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedDictionaryItemDeletingEventHandler.cs" />
+    <Compile Include="EventHandlers\EnterspeedMediaItemSavedEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedDictionaryItemSavedEventHandler.cs" />
     <Compile Include="Exceptions\JobHandlingException.cs" />
     <Compile Include="Extensions\EnterspeedConfigurationExtensions.cs" />
@@ -312,11 +314,16 @@
     <Compile Include="Guards\ContentCultureUrlRequiredGuard.cs" />
     <Compile Include="Guards\EnterspeedContentHandlingGuardCollection.cs" />
     <Compile Include="Guards\EnterspeedContentHandlingGuardCollectionBuilder.cs" />
+    <Compile Include="Guards\EnterspeedMediaHandlingGuardCollection.cs" />
     <Compile Include="Guards\EnterspeedDictionaryItemHandlingGuardCollection.cs" />
+    <Compile Include="Guards\EnterspeedMediaHandlingGuardCollectionBuilder.cs" />
     <Compile Include="Guards\EnterspeedDictionaryItemHandlingGuardCollectionBuilder.cs" />
     <Compile Include="Guards\IEnterspeedContentHandlingGuard.cs" />
+    <Compile Include="Guards\IEnterspeedMediaHandlingGuard.cs" />
     <Compile Include="Guards\IEnterspeedDictionaryItemHandlingGuard.cs" />
     <Compile Include="Handlers\Content\EnterspeedContentDeleteJobHandler.cs" />
+    <Compile Include="Handlers\Media\EnterspeedMediaDeleteJobHandler.cs" />
+    <Compile Include="Handlers\Media\EnterspeedMediaPublishJobHandler.cs" />
     <Compile Include="Handlers\Dictionaries\EnterspeedDictionaryItemDeleteJobHandler.cs" />
     <Compile Include="Handlers\EnterspeedJobHandlerCollection.cs" />
     <Compile Include="Handlers\EnterspeedJobHandlerCollectionBuilder.cs" />
@@ -336,6 +343,7 @@
     <Compile Include="Models\EnterspeedJobHandlerResponse.cs" />
     <Compile Include="Models\Grid\GridControl.cs" />
     <Compile Include="Models\UmbracoContentEntity.cs" />
+    <Compile Include="Models\UmbracoMediaEntity.cs" />
     <Compile Include="Models\UmbracoDictionaryEntity.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Providers\EnterspeedConnectionProvider.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -298,6 +298,7 @@
     <Compile Include="EventHandlers\EnterspeedContentPublishingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedContentTrashingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedContentUnpublishingEventHandler.cs" />
+    <Compile Include="EventHandlers\EnterspeedMediaMovedEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedMediaTrashedEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedDictionaryItemDeletingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedMediaItemSavedEventHandler.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -298,7 +298,7 @@
     <Compile Include="EventHandlers\EnterspeedContentPublishingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedContentTrashingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedContentUnpublishingEventHandler.cs" />
-    <Compile Include="EventHandlers\EnterspeedMediaItemDeletingEventHandler.cs" />
+    <Compile Include="EventHandlers\EnterspeedMediaTrashedEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedDictionaryItemDeletingEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedMediaItemSavedEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedDictionaryItemSavedEventHandler.cs" />
@@ -322,7 +322,7 @@
     <Compile Include="Guards\IEnterspeedMediaHandlingGuard.cs" />
     <Compile Include="Guards\IEnterspeedDictionaryItemHandlingGuard.cs" />
     <Compile Include="Handlers\Content\EnterspeedContentDeleteJobHandler.cs" />
-    <Compile Include="Handlers\Media\EnterspeedMediaTrashingJobHandler.cs" />
+    <Compile Include="Handlers\Media\EnterspeedMediaTrashedJobHandler.cs" />
     <Compile Include="Handlers\Media\EnterspeedMediaPublishJobHandler.cs" />
     <Compile Include="Handlers\Dictionaries\EnterspeedDictionaryItemDeleteJobHandler.cs" />
     <Compile Include="Handlers\EnterspeedJobHandlerCollection.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -305,6 +305,7 @@
     <Compile Include="EventHandlers\EnterspeedDictionaryItemSavedEventHandler.cs" />
     <Compile Include="Exceptions\JobHandlingException.cs" />
     <Compile Include="Extensions\EnterspeedConfigurationExtensions.cs" />
+    <Compile Include="Extensions\MediaExtensions.cs" />
     <Compile Include="Extensions\PropertyExtensions.cs" />
     <Compile Include="Extensions\StringExtensions.cs" />
     <Compile Include="Extensions\UriExtensions.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -322,7 +322,7 @@
     <Compile Include="Guards\IEnterspeedMediaHandlingGuard.cs" />
     <Compile Include="Guards\IEnterspeedDictionaryItemHandlingGuard.cs" />
     <Compile Include="Handlers\Content\EnterspeedContentDeleteJobHandler.cs" />
-    <Compile Include="Handlers\Media\EnterspeedMediaDeleteJobHandler.cs" />
+    <Compile Include="Handlers\Media\EnterspeedMediaTrashingJobHandler.cs" />
     <Compile Include="Handlers\Media\EnterspeedMediaPublishJobHandler.cs" />
     <Compile Include="Handlers\Dictionaries\EnterspeedDictionaryItemDeleteJobHandler.cs" />
     <Compile Include="Handlers\EnterspeedJobHandlerCollection.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedContentTrashingEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedContentTrashingEventHandler.cs
@@ -27,9 +27,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
             IEnterspeedConfigurationService configurationService,
             IScopeProvider scopeProvider,
             IEnterspeedJobFactory enterspeedJobFactory)
-            : base(
-                umbracoContextFactory, enterspeedJobRepository, jobsHandlingService, configurationService,
-                scopeProvider)
+            : base(umbracoContextFactory, enterspeedJobRepository, jobsHandlingService, configurationService, scopeProvider)
         {
             _enterspeedJobFactory = enterspeedJobFactory;
         }

--- a/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaItemDeletingEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaItemDeletingEventHandler.cs
@@ -1,0 +1,102 @@
+using System.Collections.Generic;
+using System.Linq;
+using Enterspeed.Source.UmbracoCms.V8.Data.Models;
+using Enterspeed.Source.UmbracoCms.V8.Data.Repositories;
+using Enterspeed.Source.UmbracoCms.V8.Factories;
+using Enterspeed.Source.UmbracoCms.V8.Services;
+using Umbraco.Core.Composing;
+using Umbraco.Core.Events;
+using Umbraco.Core.Models;
+using Umbraco.Core.Scoping;
+using Umbraco.Core.Services;
+using Umbraco.Core.Services.Implement;
+using Umbraco.Web;
+
+namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
+{
+    public class EnterspeedMediaItemDeletingEventHandler : BaseEnterspeedEventHandler, IComponent
+    {
+        private readonly IEnterspeedJobFactory _enterspeedJobFactory;
+
+        public EnterspeedMediaItemDeletingEventHandler(
+            IUmbracoContextFactory umbracoContextFactory,
+            IEnterspeedJobRepository enterspeedJobRepository,
+            IEnterspeedJobsHandlingService jobsHandlingService,
+            IEnterspeedConfigurationService configurationService,
+            IScopeProvider scopeProvider,
+            IEnterspeedJobFactory enterspeedJobFactory)
+            : base(
+                umbracoContextFactory,
+                enterspeedJobRepository,
+                jobsHandlingService,
+                configurationService,
+                scopeProvider)
+        {
+            _enterspeedJobFactory = enterspeedJobFactory;
+        }
+
+        public void Initialize()
+        {
+            MediaService.Deleting += MediaService_Deleting;
+        }
+
+        private void MediaService_Deleting(IMediaService sender, DeleteEventArgs<IMedia> e)
+        {
+            var isPublishConfigured = _configurationService.IsPublishConfigured();
+            var isPreviewConfigured = _configurationService.IsPreviewConfigured();
+
+            if (!isPublishConfigured && !isPreviewConfigured)
+            {
+                return;
+            }
+
+            var entities = e.DeletedEntities.ToList();
+            var jobs = new List<EnterspeedJob>();
+            using (var context = _umbracoContextFactory.EnsureUmbracoContext())
+            {
+                foreach (var mediaItem in entities)
+                {
+                    List<IMedia> descendants = null;
+                    foreach (var culture in mediaItem.AvailableCultures)
+                    {
+                        if (isPublishConfigured)
+                        {
+                            jobs.Add(_enterspeedJobFactory.GetDeleteJob(mediaItem, culture, EnterspeedContentState.Publish));
+                        }
+
+                        if (isPreviewConfigured)
+                        {
+                            jobs.Add(_enterspeedJobFactory.GetDeleteJob(mediaItem, culture, EnterspeedContentState.Preview));
+                        }
+
+                        if (descendants != null)
+                        {
+                            continue;
+                        }
+
+                        descendants = Current.Services.MediaService.GetPagedDescendants(mediaItem.Id, int.MaxValue, int.MaxValue, out var totalRecords).ToList();
+
+                        if (totalRecords <= 0)
+                        {
+                            continue;
+                        }
+
+                        foreach (var descendant in descendants)
+                        {
+                            if (isPublishConfigured)
+                            {
+                                jobs.Add(_enterspeedJobFactory.GetDeleteJob(descendant, "*", EnterspeedContentState.Publish));
+                            }
+                        }
+                    }
+                }
+            }
+
+            EnqueueJobs(jobs);
+        }
+
+        public void Terminate()
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaItemSavedEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaItemSavedEventHandler.cs
@@ -17,6 +17,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
 {
     public class EnterspeedMediaItemSavedEventHandler : BaseEnterspeedEventHandler, IComponent
     {
+        private const int IndexPageSize = 9999;
         private readonly IEnterspeedJobFactory _enterspeedJobFactory;
         private readonly IMediaService _mediaService;
 
@@ -61,7 +62,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
             {
                 if (mediaItem.ContentType.Alias.Equals("Folder"))
                 {
-                    var mediaItems = _mediaService.GetPagedDescendants(mediaItem.Id, 0, 99999, out var totalRecords).ToList();
+                    var mediaItems = _mediaService.GetPagedDescendants(mediaItem.Id, 0, IndexPageSize, out var totalRecords).ToList();
                     if (totalRecords > 0)
                     {
                         foreach (var item in mediaItems)

--- a/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaMovedEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaMovedEventHandler.cs
@@ -11,24 +11,21 @@ using Umbraco.Core.Scoping;
 using Umbraco.Core.Services;
 using Umbraco.Core.Services.Implement;
 using Umbraco.Web;
-using Umbraco.Web.Security;
 
 namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
 {
-    public class EnterspeedMediaItemSavedEventHandler : BaseEnterspeedEventHandler, IComponent
+    public class EnterspeedMediaMovedEventHandler : BaseEnterspeedEventHandler, IComponent
     {
         private readonly IEnterspeedJobFactory _enterspeedJobFactory;
         private readonly IMediaService _mediaService;
 
-        public EnterspeedMediaItemSavedEventHandler(
+        public EnterspeedMediaMovedEventHandler(
             IUmbracoContextFactory umbracoContextFactory,
             IEnterspeedJobRepository enterspeedJobRepository,
             IEnterspeedJobsHandlingService jobsHandlingService,
             IEnterspeedConfigurationService configurationService,
             IScopeProvider scopeProvider,
-            IEnterspeedJobFactory enterspeedJobFactory,
-            IMediaService mediaService
-        )
+            IEnterspeedJobFactory enterspeedJobFactory, IMediaService mediaService)
             : base(
                 umbracoContextFactory,
                 enterspeedJobRepository,
@@ -42,10 +39,11 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
 
         public void Initialize()
         {
-            MediaService.Saved += MediaService_Saved;
+            MediaService.Moved += MediaService_Moved;
+
         }
 
-        private void MediaService_Saved(IMediaService sender, SaveEventArgs<IMedia> e)
+        private void MediaService_Moved(IMediaService sender, MoveEventArgs<IMedia> e)
         {
             var isPublishConfigured = _configurationService.IsPublishConfigured();
 
@@ -54,10 +52,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
                 return;
             }
 
-            var entities = e.SavedEntities.ToList();
+            var entities = e.MoveInfoCollection.ToList();
             var jobs = new List<EnterspeedJob>();
 
-            foreach (var mediaItem in entities)
+            foreach (var mediaItem in entities.Select(ei => ei.Entity))
             {
                 if (mediaItem.ContentType.Alias.Equals("Folder"))
                 {

--- a/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaMovedEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaMovedEventHandler.cs
@@ -16,6 +16,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
 {
     public class EnterspeedMediaMovedEventHandler : BaseEnterspeedEventHandler, IComponent
     {
+        private const int IndexPageSize = 9999;
         private readonly IEnterspeedJobFactory _enterspeedJobFactory;
         private readonly IMediaService _mediaService;
 
@@ -25,7 +26,8 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
             IEnterspeedJobsHandlingService jobsHandlingService,
             IEnterspeedConfigurationService configurationService,
             IScopeProvider scopeProvider,
-            IEnterspeedJobFactory enterspeedJobFactory, IMediaService mediaService)
+            IEnterspeedJobFactory enterspeedJobFactory,
+            IMediaService mediaService)
             : base(
                 umbracoContextFactory,
                 enterspeedJobRepository,
@@ -40,7 +42,6 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
         public void Initialize()
         {
             MediaService.Moved += MediaService_Moved;
-
         }
 
         private void MediaService_Moved(IMediaService sender, MoveEventArgs<IMedia> e)
@@ -52,14 +53,14 @@ namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
                 return;
             }
 
-            var entities = e.MoveInfoCollection.ToList();
+            var entities = e.MoveInfoCollection.Select(ei => ei.Entity).ToList();
             var jobs = new List<EnterspeedJob>();
 
-            foreach (var mediaItem in entities.Select(ei => ei.Entity))
+            foreach (var mediaItem in entities)
             {
                 if (mediaItem.ContentType.Alias.Equals("Folder"))
                 {
-                    var mediaItems = _mediaService.GetPagedDescendants(mediaItem.Id, 0, 99999, out var totalRecords).ToList();
+                    var mediaItems = _mediaService.GetPagedDescendants(mediaItem.Id, 0, IndexPageSize, out var totalRecords).ToList();
                     if (totalRecords > 0)
                     {
                         foreach (var item in mediaItems)

--- a/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaTrashedEventHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/EventHandlers/EnterspeedMediaTrashedEventHandler.cs
@@ -14,11 +14,11 @@ using Umbraco.Web;
 
 namespace Enterspeed.Source.UmbracoCms.V8.EventHandlers
 {
-    public class EnterspeedMediaItemDeletingEventHandler : BaseEnterspeedEventHandler, IComponent
+    public class EnterspeedMediaTrashedEventHandler : BaseEnterspeedEventHandler, IComponent
     {
         private readonly IEnterspeedJobFactory _enterspeedJobFactory;
 
-        public EnterspeedMediaItemDeletingEventHandler(
+        public EnterspeedMediaTrashedEventHandler(
             IUmbracoContextFactory umbracoContextFactory,
             IEnterspeedJobRepository enterspeedJobRepository,
             IEnterspeedJobsHandlingService jobsHandlingService,

--- a/src/Enterspeed.Source.UmbracoCms.V8/Extensions/MediaExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Extensions/MediaExtensions.cs
@@ -1,0 +1,24 @@
+﻿using Enterspeed.Source.UmbracoCms.V8.Models.Configuration;
+using Newtonsoft.Json;
+using Umbraco.Core;
+using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors.ValueConverters;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Extensions
+{
+    public static class MediaExtensions
+    {
+        public static string GetMediaUrl(this IMedia media, EnterspeedUmbracoConfiguration configuration)
+        {
+            var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
+            var url = string.Empty;
+
+            if (umbracoFile != null)
+            {
+                url = configuration.MediaDomain + JsonConvert.DeserializeObject<ImageCropperValue>(umbracoFile).Src;
+            }
+
+            return url;
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Factories/EnterspeedJobFactory.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Factories/EnterspeedJobFactory.cs
@@ -76,7 +76,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Factories
             var now = DateTime.UtcNow;
             return new EnterspeedJob
             {
-                EntityId = media.Key.ToString(),
+                EntityId = media.Id.ToString(),
                 EntityType = EnterspeedJobEntityType.Media,
                 Culture = culture,
                 JobType = EnterspeedJobType.Publish,
@@ -110,7 +110,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Factories
             var now = DateTime.UtcNow;
             return new EnterspeedJob
             {
-                EntityId = media.Key.ToString(),
+                EntityId = media.Id.ToString(),
                 EntityType = EnterspeedJobEntityType.Media,
                 Culture = culture,
                 JobType = EnterspeedJobType.Delete,

--- a/src/Enterspeed.Source.UmbracoCms.V8/Factories/EnterspeedJobFactory.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Factories/EnterspeedJobFactory.cs
@@ -111,7 +111,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Factories
             return new EnterspeedJob
             {
                 EntityId = media.Key.ToString(),
-                EntityType = EnterspeedJobEntityType.Dictionary,
+                EntityType = EnterspeedJobEntityType.Media,
                 Culture = culture,
                 JobType = EnterspeedJobType.Delete,
                 State = EnterspeedJobState.Pending,

--- a/src/Enterspeed.Source.UmbracoCms.V8/Factories/EnterspeedJobFactory.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Factories/EnterspeedJobFactory.cs
@@ -71,12 +71,46 @@ namespace Enterspeed.Source.UmbracoCms.V8.Factories
             };
         }
 
+        public EnterspeedJob GetPublishJob(IMedia media, string culture, EnterspeedContentState state)
+        {
+            var now = DateTime.UtcNow;
+            return new EnterspeedJob
+            {
+                EntityId = media.Key.ToString(),
+                EntityType = EnterspeedJobEntityType.Media,
+                Culture = culture,
+                JobType = EnterspeedJobType.Publish,
+                State = EnterspeedJobState.Pending,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ContentState = state,
+            };
+        }
+
+
+
         public EnterspeedJob GetDeleteJob(IDictionaryItem dictionaryItem, string culture, EnterspeedContentState state)
         {
             var now = DateTime.UtcNow;
             return new EnterspeedJob
             {
                 EntityId = dictionaryItem.Key.ToString(),
+                EntityType = EnterspeedJobEntityType.Dictionary,
+                Culture = culture,
+                JobType = EnterspeedJobType.Delete,
+                State = EnterspeedJobState.Pending,
+                CreatedAt = now,
+                UpdatedAt = now,
+                ContentState = state,
+            };
+        }
+
+        public EnterspeedJob GetDeleteJob(IMedia media, string culture, EnterspeedContentState state)
+        {
+            var now = DateTime.UtcNow;
+            return new EnterspeedJob
+            {
+                EntityId = media.Key.ToString(),
                 EntityType = EnterspeedJobEntityType.Dictionary,
                 Culture = culture,
                 JobType = EnterspeedJobType.Delete,

--- a/src/Enterspeed.Source.UmbracoCms.V8/Factories/IEnterspeedJobFactory.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Factories/IEnterspeedJobFactory.cs
@@ -10,7 +10,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Factories
         EnterspeedJob GetPublishJob(IContent content, string culture, EnterspeedContentState state);
         EnterspeedJob GetDeleteJob(IContent content, string culture, EnterspeedContentState state);
         EnterspeedJob GetPublishJob(IDictionaryItem dictionaryItem, string culture, EnterspeedContentState state);
+        EnterspeedJob GetPublishJob(IMedia media, string culture, EnterspeedContentState state);
         EnterspeedJob GetDeleteJob(IDictionaryItem dictionaryItem, string culture, EnterspeedContentState state);
+        EnterspeedJob GetDeleteJob(IMedia media, string culture, EnterspeedContentState state);
+
         EnterspeedJob GetFailedJob(EnterspeedJob job, string exception);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedMediaHandlingGuardCollection.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedMediaHandlingGuardCollection.cs
@@ -1,0 +1,15 @@
+using System.Collections.Generic;
+using Umbraco.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class
+        EnterspeedMediaHandlingGuardCollection : BuilderCollectionBase<IEnterspeedMediaHandlingGuard>
+    {
+        public EnterspeedMediaHandlingGuardCollection(
+            IEnumerable<IEnterspeedMediaHandlingGuard> items)
+            : base(items)
+        {
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedMediaHandlingGuardCollectionBuilder.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/EnterspeedMediaHandlingGuardCollectionBuilder.cs
@@ -1,0 +1,16 @@
+using Umbraco.Core.Composing;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public class EnterspeedMediaHandlingGuardCollectionBuilder
+        : OrderedCollectionBuilderBase<EnterspeedMediaHandlingGuardCollectionBuilder,
+            EnterspeedMediaHandlingGuardCollection,
+            IEnterspeedMediaHandlingGuard>
+    {
+        public EnterspeedMediaHandlingGuardCollectionBuilder()
+        {
+        }
+
+        protected override EnterspeedMediaHandlingGuardCollectionBuilder This => this;
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedMediaHandlingGuard.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Guards/IEnterspeedMediaHandlingGuard.cs
@@ -1,0 +1,15 @@
+using Umbraco.Core.Models;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Guards
+{
+    public interface IEnterspeedMediaHandlingGuard
+    {
+        /// <summary>
+        /// Validates if dictionary item can be ingested.
+        /// </summary>
+        /// <param name="media">Dictionary item for ingest.</param>
+        /// <param name="culture">Culture of dictionary item.</param>
+        /// <returns>True or false, if is valid for ingest or not.</returns>
+        bool CanIngest(IMedia media, string culture);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaDeleteJobHandler.cs
@@ -1,0 +1,47 @@
+﻿using System.Net;
+using Enterspeed.Source.Sdk.Api.Services;
+using Enterspeed.Source.UmbracoCms.V8.Data.Models;
+using Enterspeed.Source.UmbracoCms.V8.Exceptions;
+using Enterspeed.Source.UmbracoCms.V8.Models;
+using Enterspeed.Source.UmbracoCms.V8.Providers;
+using Enterspeed.Source.UmbracoCms.V8.Services;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
+{
+    public class EnterspeedMediaDeleteJobHandler : IEnterspeedJobHandler
+    {
+        private readonly IEnterspeedIngestService _enterspeedIngestService;
+        private readonly IEntityIdentityService _entityIdentityService;
+        private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
+
+        public EnterspeedMediaDeleteJobHandler
+        (
+            IEnterspeedIngestService enterspeedIngestService,
+            IEntityIdentityService entityIdentityService,
+            IEnterspeedConnectionProvider enterspeedConnectionProvider)
+        {
+            _enterspeedIngestService = enterspeedIngestService;
+            _entityIdentityService = entityIdentityService;
+            _enterspeedConnectionProvider = enterspeedConnectionProvider;
+        }
+
+        public bool CanHandle(EnterspeedJob job)
+        {
+            return
+               _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
+               && job.EntityType == EnterspeedJobEntityType.Media
+               && job.JobType == EnterspeedJobType.Delete
+               && job.ContentState == EnterspeedContentState.Publish;
+        }
+
+        public void Handle(EnterspeedJob job)
+        {
+            var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
+            var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
+            if (!deleteResponse.Success && deleteResponse.Status != HttpStatusCode.NotFound)
+            {
+                throw new JobHandlingException($"Failed deleting entity ({job.EntityId}/{job.Culture}). Message: {deleteResponse.Message}");
+            }
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -80,12 +80,12 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
         {
             try
             {
-                return new UmbracoMediaEntity(media, _enterspeedPropertyService, _entityIdentityService, job.Culture);
+                return new UmbracoMediaEntity(media, _enterspeedPropertyService, _entityIdentityService);
             }
             catch (Exception e)
             {
                 throw new JobHandlingException(
-                    $"Failed creating entity ({job.EntityId}/{job.Culture}). Message: {e.Message}. StackTrace: {e.StackTrace}");
+                    $"Failed creating entity ({job.EntityId}). Message: {e.Message}. StackTrace: {e.StackTrace}");
             }
         }
 

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -59,9 +59,9 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
 
         protected virtual IMedia GetMedia(EnterspeedJob job)
         {
-            var isMediaId = Guid.TryParse(job.EntityId, out var mediaId);
+            var parsed = int.TryParse(job.EntityId, out var parsedId);
+            var media = parsed ? _mediaService.GetById(parsedId) : null;
 
-            var media = isMediaId ? _mediaService.GetById(mediaId) : null;
             if (media == null)
             {
                 throw new JobHandlingException($"Media with id {job.EntityId} not in database");

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -1,0 +1,105 @@
+﻿using System;
+using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Services;
+using Enterspeed.Source.UmbracoCms.V8.Data.Models;
+using Enterspeed.Source.UmbracoCms.V8.Exceptions;
+using Enterspeed.Source.UmbracoCms.V8.Models;
+using Enterspeed.Source.UmbracoCms.V8.Providers;
+using Enterspeed.Source.UmbracoCms.V8.Services;
+using Umbraco.Core.Models;
+using Umbraco.Core.Services;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
+{
+    public class EnterspeedMediaPublishJobHandler : IEnterspeedJobHandler
+    {
+        private readonly IEnterspeedPropertyService _enterspeedPropertyService;
+        private readonly IEnterspeedIngestService _enterspeedIngestService;
+        private readonly IEntityIdentityService _entityIdentityService;
+        private readonly IEnterspeedGuardService _enterspeedGuardService;
+        private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
+        private readonly IMediaService _mediaService;
+
+        public EnterspeedMediaPublishJobHandler(
+            IEnterspeedPropertyService enterspeedPropertyService,
+            IEnterspeedIngestService enterspeedIngestService,
+            IEntityIdentityService entityIdentityService,
+            IEnterspeedGuardService enterspeedGuardService,
+            IEnterspeedConnectionProvider enterspeedConnectionProvider,
+            IMediaService mediaService)
+        {
+            _enterspeedPropertyService = enterspeedPropertyService;
+            _enterspeedIngestService = enterspeedIngestService;
+            _entityIdentityService = entityIdentityService;
+            _enterspeedGuardService = enterspeedGuardService;
+            _enterspeedConnectionProvider = enterspeedConnectionProvider;
+            _mediaService = mediaService;
+        }
+
+        public bool CanHandle(EnterspeedJob job)
+        {
+            return
+                _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
+                && job.EntityType == EnterspeedJobEntityType.Media
+                && job.ContentState == EnterspeedContentState.Publish
+                && job.JobType == EnterspeedJobType.Publish;
+        }
+
+        public void Handle(EnterspeedJob job)
+        {
+            var media = GetMedia(job);
+            if (!CanIngest(media, job))
+            {
+                return;
+            }
+
+            var umbracoData = CreateUmbracoMediaEntity(media, job);
+            Ingest(umbracoData, job);
+        }
+
+        protected virtual IMedia GetMedia(EnterspeedJob job)
+        {
+            var isMediaId = Guid.TryParse(job.EntityId, out var mediaId);
+
+            var media = isMediaId ? _mediaService.GetById(mediaId) : null;
+            if (media == null)
+            {
+                throw new JobHandlingException($"Media with id {job.EntityId} not in database");
+            }
+
+            return media;
+        }
+
+        protected virtual bool CanIngest(IMedia media, EnterspeedJob job)
+        {
+            // Check if any of guards are against it
+            return _enterspeedGuardService.CanIngest(media, job.Culture);
+        }
+
+        protected virtual UmbracoMediaEntity CreateUmbracoMediaEntity(IMedia media, EnterspeedJob job)
+        {
+            try
+            {
+                return new UmbracoMediaEntity(media, _enterspeedPropertyService, _entityIdentityService, job.Culture);
+            }
+            catch (Exception e)
+            {
+                throw new JobHandlingException(
+                    $"Failed creating entity ({job.EntityId}/{job.Culture}). Message: {e.Message}. StackTrace: {e.StackTrace}");
+            }
+        }
+
+        protected virtual void Ingest(IEnterspeedEntity umbracoData, EnterspeedJob job)
+        {
+            var ingestResponse = _enterspeedIngestService.Save(umbracoData, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
+            if (!ingestResponse.Success)
+            {
+                var message = ingestResponse.Exception != null
+                    ? ingestResponse.Exception.Message
+                    : ingestResponse.Message;
+                throw new JobHandlingException(
+                    $"Failed ingesting entity ({job.EntityId}/{job.Culture}). Message: {message}");
+            }
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -19,6 +19,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
         private readonly IEnterspeedGuardService _enterspeedGuardService;
         private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
         private readonly IMediaService _mediaService;
+        private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
 
         public EnterspeedMediaPublishJobHandler(
             IEnterspeedPropertyService enterspeedPropertyService,
@@ -26,7 +27,8 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
             IEntityIdentityService entityIdentityService,
             IEnterspeedGuardService enterspeedGuardService,
             IEnterspeedConnectionProvider enterspeedConnectionProvider,
-            IMediaService mediaService)
+            IMediaService mediaService,
+            IEnterspeedConfigurationService enterspeedConfigurationService)
         {
             _enterspeedPropertyService = enterspeedPropertyService;
             _enterspeedIngestService = enterspeedIngestService;
@@ -34,6 +36,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
             _enterspeedGuardService = enterspeedGuardService;
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
             _mediaService = mediaService;
+            _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
         public bool CanHandle(EnterspeedJob job)
@@ -80,7 +83,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
         {
             try
             {
-                return new UmbracoMediaEntity(media, _enterspeedPropertyService, _entityIdentityService);
+                return new UmbracoMediaEntity(media, _enterspeedPropertyService, _entityIdentityService, _enterspeedConfigurationService);
             }
             catch (Exception e)
             {

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaTrashedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaTrashedJobHandler.cs
@@ -9,13 +9,13 @@ using Umbraco.Core.Services;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
 {
-    public class EnterspeedMediaTrashingJobHandler : IEnterspeedJobHandler
+    public class EnterspeedMediaTrashedJobHandler : IEnterspeedJobHandler
     {
         private readonly IEnterspeedIngestService _enterspeedIngestService;
         private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
         private readonly IMediaService _mediaService;
 
-        public EnterspeedMediaTrashingJobHandler
+        public EnterspeedMediaTrashedJobHandler
         (
             IEnterspeedIngestService enterspeedIngestService,
             IEnterspeedConnectionProvider enterspeedConnectionProvider,
@@ -37,8 +37,8 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
 
         public void Handle(EnterspeedJob job)
         {
-            var isMediaId = Guid.TryParse(job.EntityId, out var mediaId);
-            var media = isMediaId ? _mediaService.GetById(mediaId) : null;
+            var parsed = int.TryParse(job.EntityId, out var parsedId);
+            var media = parsed ? _mediaService.GetById(parsedId) : null;
 
             var deleteResponse = _enterspeedIngestService.Delete(media?.Id.ToString(), _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
             if (!deleteResponse.Success && deleteResponse.Status != HttpStatusCode.NotFound)

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaTrashingJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaTrashingJobHandler.cs
@@ -1,28 +1,29 @@
-﻿using System.Net;
+﻿using System;
+using System.Net;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.V8.Data.Models;
 using Enterspeed.Source.UmbracoCms.V8.Exceptions;
 using Enterspeed.Source.UmbracoCms.V8.Models;
 using Enterspeed.Source.UmbracoCms.V8.Providers;
-using Enterspeed.Source.UmbracoCms.V8.Services;
+using Umbraco.Core.Services;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
 {
-    public class EnterspeedMediaDeleteJobHandler : IEnterspeedJobHandler
+    public class EnterspeedMediaTrashingJobHandler : IEnterspeedJobHandler
     {
         private readonly IEnterspeedIngestService _enterspeedIngestService;
-        private readonly IEntityIdentityService _entityIdentityService;
         private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
+        private readonly IMediaService _mediaService;
 
-        public EnterspeedMediaDeleteJobHandler
+        public EnterspeedMediaTrashingJobHandler
         (
             IEnterspeedIngestService enterspeedIngestService,
-            IEntityIdentityService entityIdentityService,
-            IEnterspeedConnectionProvider enterspeedConnectionProvider)
+            IEnterspeedConnectionProvider enterspeedConnectionProvider,
+            IMediaService mediaService)
         {
             _enterspeedIngestService = enterspeedIngestService;
-            _entityIdentityService = entityIdentityService;
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
+            _mediaService = mediaService;
         }
 
         public bool CanHandle(EnterspeedJob job)
@@ -36,8 +37,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
 
         public void Handle(EnterspeedJob job)
         {
-            var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
-            var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
+            var isMediaId = Guid.TryParse(job.EntityId, out var mediaId);
+            var media = isMediaId ? _mediaService.GetById(mediaId) : null;
+
+            var deleteResponse = _enterspeedIngestService.Delete(media?.Id.ToString(), _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
             if (!deleteResponse.Success && deleteResponse.Status != HttpStatusCode.NotFound)
             {
                 throw new JobHandlingException($"Failed deleting entity ({job.EntityId}/{job.Culture}). Message: {deleteResponse.Message}");

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/Api/SeedResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/Api/SeedResponse.cs
@@ -5,5 +5,6 @@
         public int JobsAdded { get; set; }
         public int ContentCount { get; set; }
         public int DictionaryCount { get; set; }
+        public long MediaCount { get; set; }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
@@ -1,5 +1,4 @@
 ﻿using System.Collections.Generic;
-using System.Web;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V8.Services;

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
@@ -1,0 +1,34 @@
+﻿using System.Collections.Generic;
+using Enterspeed.Source.Sdk.Api.Models;
+using Enterspeed.Source.Sdk.Api.Models.Properties;
+using Enterspeed.Source.UmbracoCms.V8.Services;
+using Umbraco.Core.Models;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Models
+{
+    public class UmbracoMediaEntity : IEnterspeedEntity
+    {
+        private readonly IMedia _media;
+        private readonly IEntityIdentityService _entityIdentityService;
+        private readonly string _culture;
+
+        public UmbracoMediaEntity(
+            IMedia media,
+            IEnterspeedPropertyService propertyService,
+            IEntityIdentityService entityIdentityService,
+            string culture)
+        {
+            _media = media;
+            _entityIdentityService = entityIdentityService;
+            _culture = culture;
+            Properties = propertyService.GetProperties(_media, _culture);
+        }
+
+        public string Id => _entityIdentityService.GetId(_media);
+        public string Type => "umbMedia";
+        public string Url => null;
+        public string[] Redirects => null;
+        public string ParentId => _entityIdentityService.GetId(_media.ParentId, _culture);
+        public IDictionary<string, IEnterspeedProperty> Properties { get; }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
@@ -1,11 +1,9 @@
 ﻿using System.Collections.Generic;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
+using Enterspeed.Source.UmbracoCms.V8.Extensions;
 using Enterspeed.Source.UmbracoCms.V8.Services;
-using Newtonsoft.Json;
-using Umbraco.Core;
 using Umbraco.Core.Models;
-using Umbraco.Core.PropertyEditors.ValueConverters;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Models
 {
@@ -17,13 +15,13 @@ namespace Enterspeed.Source.UmbracoCms.V8.Models
         public UmbracoMediaEntity(
             IMedia media,
             IEnterspeedPropertyService propertyService,
-            IEntityIdentityService entityIdentityService)
+            IEntityIdentityService entityIdentityService,
+            IEnterspeedConfigurationService enterspeedConfigurationService)
         {
             _media = media;
             _entityIdentityService = entityIdentityService;
-            var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
-            var url = JsonConvert.DeserializeObject<ImageCropperValue>(umbracoFile).Src;
-            Url = url;
+
+            Url = _media.GetMediaUrl(enterspeedConfigurationService.GetConfiguration());
             Properties = propertyService.GetProperties(_media);
         }
 

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
@@ -1,8 +1,12 @@
 ﻿using System.Collections.Generic;
+using System.Web;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V8.Services;
+using Newtonsoft.Json;
+using Umbraco.Core;
 using Umbraco.Core.Models;
+using Umbraco.Core.PropertyEditors.ValueConverters;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Models
 {
@@ -10,25 +14,25 @@ namespace Enterspeed.Source.UmbracoCms.V8.Models
     {
         private readonly IMedia _media;
         private readonly IEntityIdentityService _entityIdentityService;
-        private readonly string _culture;
 
         public UmbracoMediaEntity(
             IMedia media,
             IEnterspeedPropertyService propertyService,
-            IEntityIdentityService entityIdentityService,
-            string culture)
+            IEntityIdentityService entityIdentityService)
         {
             _media = media;
             _entityIdentityService = entityIdentityService;
-            _culture = culture;
-            Properties = propertyService.GetProperties(_media, _culture);
+            var umbracoFile = media.GetValue<string>(Constants.Conventions.Media.File);
+            var url = JsonConvert.DeserializeObject<ImageCropperValue>(umbracoFile).Src;
+            Url = url;
+            Properties = propertyService.GetProperties(_media);
         }
 
         public string Id => _entityIdentityService.GetId(_media);
         public string Type => "umbMedia";
-        public string Url => null;
+        public string Url { get; set; }
         public string[] Redirects => null;
-        public string ParentId => _entityIdentityService.GetId(_media.ParentId, _culture);
+        public string ParentId => _entityIdentityService.GetId(_media.ParentId.ToString());
         public IDictionary<string, IEnterspeedProperty> Properties { get; }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedGuardService.cs
@@ -11,15 +11,19 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         private readonly ILogger _logger;
         private readonly EnterspeedContentHandlingGuardCollection _contentGuards;
         private readonly EnterspeedDictionaryItemHandlingGuardCollection _dictionaryItemGuards;
+        private readonly EnterspeedMediaHandlingGuardCollection _mediaHandlingGuards;
+
 
         public EnterspeedGuardService(
             EnterspeedContentHandlingGuardCollection contentGuards,
             EnterspeedDictionaryItemHandlingGuardCollection dictionaryItemGuards,
-            ILogger logger)
+            ILogger logger,
+            EnterspeedMediaHandlingGuardCollection mediaHandlingGuards)
         {
             _contentGuards = contentGuards;
             _dictionaryItemGuards = dictionaryItemGuards;
             _logger = logger;
+            _mediaHandlingGuards = mediaHandlingGuards;
         }
 
         public bool CanIngest(IPublishedContent content, string culture)
@@ -50,6 +54,22 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             _logger.Debug<EnterspeedGuardService>(
                 "Dictionary item {dictionaryItemId} with {culture} culture, ingest avoided by '{guard}'.",
                 dictionaryItem.Id,
+                culture,
+                blockingGuard.GetType().Name);
+            return false;
+        }
+
+        public bool CanIngest(IMedia media, string culture)
+        {
+            var blockingGuard = _mediaHandlingGuards.FirstOrDefault(guard => !guard.CanIngest(media, culture));
+            if (blockingGuard == null)
+            {
+                return true;
+            }
+
+            _logger.Debug<EnterspeedGuardService>(
+                "Media {mediaId} with {culture} culture, ingest avoided by '{guard}'.",
+                media.Id,
                 culture,
                 blockingGuard.GetType().Name);
             return false;

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
@@ -73,6 +73,14 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             return output;
         }
 
+        public IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media, string culture)
+        {
+            var enterspeedProperties = new Dictionary<string, IEnterspeedProperty>();
+            enterspeedProperties.Add("name", new StringEnterspeedProperty("name", media.Name));
+
+            return enterspeedProperties;
+        }
+
         private IEnterspeedProperty CreateMetaData(IPublishedContent content, string culture)
         {
             var metaData = new Dictionary<string, IEnterspeedProperty>

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
@@ -73,10 +73,19 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             return output;
         }
 
-        public IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media, string culture)
+        public IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media)
         {
-            var enterspeedProperties = new Dictionary<string, IEnterspeedProperty>();
-            enterspeedProperties.Add("name", new StringEnterspeedProperty("name", media.Name));
+            var enterspeedProperties = new Dictionary<string, IEnterspeedProperty>
+            {
+                { "name", new StringEnterspeedProperty("name", media.Name) },
+                { "size", new StringEnterspeedProperty("size", media.GetValue<string>("umbracoBytes")) },
+                { "type", new StringEnterspeedProperty("type", media.GetValue<string>("umbracoExtension")) },
+                { "path", new StringEnterspeedProperty("path", media.Path) },
+                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "level", new NumberEnterspeedProperty("level", media.Level) },
+                { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
+            };
 
             return enterspeedProperties;
         }
@@ -108,6 +117,20 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
 
             return ids
                 .Select(x => new StringEnterspeedProperty(null, _identityService.GetId(x, culture)))
+                .ToArray();
+        }
+
+        private IEnterspeedProperty[] GetNodePath(IMedia media)
+        {
+            var ids = media.Path
+                .Split(new[] { "," }, StringSplitOptions.RemoveEmptyEntries)
+                .Select(int.Parse)
+                .ToList();
+
+            ids.Remove(-1);
+
+            return ids
+                .Select(x => new StringEnterspeedProperty(null, _identityService.GetId(media)))
                 .ToArray();
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedGuardService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedGuardService.cs
@@ -7,5 +7,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
     {
         bool CanIngest(IPublishedContent content, string culture);
         bool CanIngest(IDictionaryItem dictionaryItem, string culture);
+        bool CanIngest(IMedia media, string culture);
+
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedPropertyService.cs
@@ -10,6 +10,6 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         IDictionary<string, IEnterspeedProperty> GetProperties(IPublishedContent content, string culture = null);
         IDictionary<string, IEnterspeedProperty> ConvertProperties(IEnumerable<IPublishedProperty> properties, string culture = null);
         IDictionary<string, IEnterspeedProperty> GetProperties(IDictionaryItem dictionaryItem, string culture);
-        IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media, string culture);
+        IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEnterspeedPropertyService.cs
@@ -10,5 +10,6 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         IDictionary<string, IEnterspeedProperty> GetProperties(IPublishedContent content, string culture = null);
         IDictionary<string, IEnterspeedProperty> ConvertProperties(IEnumerable<IPublishedProperty> properties, string culture = null);
         IDictionary<string, IEnterspeedProperty> GetProperties(IDictionaryItem dictionaryItem, string culture);
+        IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media, string culture);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEntityIdentityService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEntityIdentityService.cs
@@ -11,5 +11,6 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         string GetId(string contentId, string culture);
         string GetId(IDictionaryItem dictionaryItem, string culture);
         string GetId(Guid? id, string culture);
+        string GetId(IMedia mediaItem);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IEntityIdentityService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IEntityIdentityService.cs
@@ -12,5 +12,6 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         string GetId(IDictionaryItem dictionaryItem, string culture);
         string GetId(Guid? id, string culture);
         string GetId(IMedia mediaItem);
+        string GetId(string id);
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/UmbracoEntityIdentityService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/UmbracoEntityIdentityService.cs
@@ -31,7 +31,12 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
 
         public string GetId(string contentId, string culture)
         {
-            return $"{contentId}-{culture}";
+            if (!string.IsNullOrWhiteSpace(culture))
+            {
+                return $"{contentId}-{culture}";
+            }
+
+            return $"{contentId}";
         }
 
         public string GetId(IDictionaryItem dictionaryItem, string culture)
@@ -44,6 +49,16 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             return GetId(dictionaryItem.Key, culture);
         }
 
+        public string GetId(IMedia mediaItem)
+        {
+            if (mediaItem == null)
+            {
+                return null;
+            }
+
+            return GetId(mediaItem.Key);
+        }
+
         public string GetId(Guid? id, string culture)
         {
             if (!id.HasValue || string.IsNullOrWhiteSpace(culture))
@@ -52,6 +67,17 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             }
 
             return GetId(id.ToString(), culture);
+        }
+
+
+        public string GetId(Guid? id)
+        {
+            if (!id.HasValue)
+            {
+                return null;
+            }
+
+            return GetId(id.ToString(), string.Empty);
         }
 
         private static string GetDefaultCulture()

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/UmbracoEntityIdentityService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/UmbracoEntityIdentityService.cs
@@ -56,7 +56,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
                 return null;
             }
 
-            return GetId(mediaItem.Key);
+            return GetId(mediaItem.Id.ToString());
         }
 
         public string GetId(Guid? id, string culture)
@@ -70,14 +70,14 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         }
 
 
-        public string GetId(Guid? id)
+        public string GetId(string id)
         {
-            if (!id.HasValue)
+            if (string.IsNullOrEmpty(id))
             {
                 return null;
             }
 
-            return GetId(id.ToString(), string.Empty);
+            return GetId(id, string.Empty);
         }
 
         private static string GetDefaultCulture()

--- a/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
+++ b/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
@@ -1,26 +1,29 @@
 ﻿<div ng-controller="SeedController as vm" class="seed-dashboard">
-	<div class="seed-dashboard-response" ng-if="vm.seedResponse !== null">
-		<h4>Seed Response</h4>
-		<div>
-			Jobs added: {{vm.seedResponse.jobsAdded}}
-		</div>
-		<div>
-			Content items: {{vm.seedResponse.contentCount}}
-		</div>
+    <div class="seed-dashboard-response" ng-if="vm.seedResponse !== null">
+        <h4>Seed Response</h4>
+        <div>
+            Jobs added: {{vm.seedResponse.jobsAdded}}
+        </div>
+        <div>
+            Content items: {{vm.seedResponse.contentCount}}
+        </div>
         <div>
             Dictionary items: {{vm.seedResponse.dictionaryCount}}
         </div>
-	</div>
-	<div class="seed-dashboard-text">
-		Seeding will queue publishing jobs for all published content within this Umbraco installation. This action can take a while to finish.
-	</div>
-	<div class="seed-dashboard-content">
-		<umb-button action="vm.seed()"
-					type="button"
-					button-style="action"
-					state="vm.seedState"
-					label="Seed"
-					disabled="vm.seedState === 'busy'">
-		</umb-button>
-	</div>
+        <div>
+            Media items: {{vm.seedResponse.mediaCount}}
+        </div>
+    </div>
+    <div class="seed-dashboard-text">
+        Seeding will queue publishing jobs for all published content within this Umbraco installation. This action can take a while to finish.
+    </div>
+    <div class="seed-dashboard-content">
+        <umb-button action="vm.seed()"
+                    type="button"
+                    button-style="action"
+                    state="vm.seedState"
+                    label="Seed"
+                    disabled="vm.seedState === 'busy'">
+        </umb-button>
+    </div>
 </div>

--- a/src/Enterspeed.Source.UmbracoCms.V9/NotificationHandlers/EnterspeedContentCacheRefresherNotificationHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/NotificationHandlers/EnterspeedContentCacheRefresherNotificationHandler.cs
@@ -74,8 +74,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.NotificationHandlers
 
                     if (node != null && isPublishConfigured)
                     {
-                        var audit = _auditService.GetPagedItemsByEntity(payload.Id, 0, 2, out var totalLogs)
-                            .FirstOrDefault();
+                        var audit = _auditService.GetPagedItemsByEntity(payload.Id, 0, 2, out var totalLogs).FirstOrDefault();
 
                         if (audit == null)
                         {


### PR DESCRIPTION
- Added functionality to push data sources for media in Umbraco 7 and 8

Ignore [https://github.com/MHove89/enterspeed-source-umbraco-cms/commit/ca0c3d6e7570b8cc68270617977f9741a48915f9](https://github.com/MHove89/enterspeed-source-umbraco-cms/commit/ca0c3d6e7570b8cc68270617977f9741a48915f9)

Somehow I managed to remove the code in a push/pull, without getting it logged in a commit. No harm done though. The commit was intended to be reverted and therefore removed.