### PR TITLE
Feature/custom properties on media

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/EnterspeedPropertyService.cs
@@ -4,8 +4,10 @@ using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V10.DataPropertyValueConverters;
 using Microsoft.Extensions.DependencyInjection;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
 using Umbraco.Extensions;
 
 namespace Enterspeed.Source.UmbracoCms.V10.Services
@@ -15,15 +17,16 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services
         private const string MetaData = "metaData";
         private readonly EnterspeedPropertyValueConverterCollection _converterCollection;
         private readonly IEntityIdentityService _identityService;
-        private readonly IServiceProvider _serviceProvider;
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
 
         public EnterspeedPropertyService(
             EnterspeedPropertyValueConverterCollection converterCollection,
-            IServiceProvider serviceProvider)
+            IServiceProvider serviceProvider,
+            IUmbracoContextFactory umbracoContextFactory)
         {
             _converterCollection = converterCollection;
-            _serviceProvider = serviceProvider;
-            _identityService = _serviceProvider.GetRequiredService<IEntityIdentityService>();
+            _umbracoContextFactory = umbracoContextFactory;
+            _identityService = serviceProvider.GetRequiredService<IEntityIdentityService>();
         }
 
         public IDictionary<string, IEnterspeedProperty> GetProperties(IPublishedContent content, string culture = null)
@@ -31,9 +34,27 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services
             var properties = content.Properties;
             var enterspeedProperties = ConvertProperties(properties, culture);
 
-            enterspeedProperties.Add(MetaData, CreateMetaData(content, culture));
+            enterspeedProperties.Add(MetaData, CreateNodeMetaData(content, culture));
 
             return enterspeedProperties;
+        }
+
+        private IEnterspeedProperty CreateNodeMetaData(IPublishedContent content, string culture)
+        {
+            var metaData = new Dictionary<string, IEnterspeedProperty>
+            {
+                ["name"] = new StringEnterspeedProperty("name", content.Name(culture)),
+                ["culture"] = new StringEnterspeedProperty("culture", culture),
+                ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
+                ["level"] = new NumberEnterspeedProperty("level", content.Level),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
+            };
+
+            MapAdditionalMetaData(metaData, content, culture);
+
+            return new ObjectEnterspeedProperty("metaData", metaData);
         }
 
         public IDictionary<string, IEnterspeedProperty> ConvertProperties(IEnumerable<IPublishedProperty> properties, string culture = null)
@@ -79,7 +100,22 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services
 
         public IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media)
         {
-            var enterspeedProperties = new Dictionary<string, IEnterspeedProperty>
+            using (var context = _umbracoContextFactory.EnsureUmbracoContext())
+            {
+                var publishedMedia = context.UmbracoContext.Media?.GetById(media.Id);
+                if (publishedMedia == null) return null;
+
+                var properties = publishedMedia.Properties.Where(p => !p.Alias.Equals(Constants.Conventions.Media.File));
+                var enterspeedProperties = ConvertProperties(properties);
+                enterspeedProperties.Add(MetaData, CreateMediaMetaProperties(media, publishedMedia));
+
+                return enterspeedProperties;
+            }
+        }
+
+        private ObjectEnterspeedProperty CreateMediaMetaProperties(IMedia media, IPublishedContent publishedMedia)
+        {
+            var metaData = new Dictionary<string, IEnterspeedProperty>
             {
                 { "name", new StringEnterspeedProperty("name", media.Name) },
                 { "size", new StringEnterspeedProperty("size", media.GetValue<string>("umbracoBytes")) },
@@ -93,25 +129,10 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services
                 { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
             };
 
-            return enterspeedProperties;
-        }
+            MapAdditionalMetaData(metaData, publishedMedia, string.Empty);
 
-        private IEnterspeedProperty CreateMetaData(IPublishedContent content, string culture)
-        {
-            var metaData = new Dictionary<string, IEnterspeedProperty>
-            {
-                ["name"] = new StringEnterspeedProperty("name", content.Name(culture)),
-                ["culture"] = new StringEnterspeedProperty("culture", culture),
-                ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
-                ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
-            };
-
-            MapAdditionalMetaData(metaData, content, culture);
-
-            return new ObjectEnterspeedProperty("metaData", metaData);
+            var metaProperties = new ObjectEnterspeedProperty(MetaData, metaData);
+            return metaProperties;
         }
 
         /// <summary>

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
@@ -7,6 +7,7 @@ using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Models;
 using Umbraco.Core.Models.PublishedContent;
+using Umbraco.Web;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Services
 {
@@ -15,10 +16,14 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
         private const string MetaData = "metaData";
         private readonly EnterspeedPropertyValueConverterCollection _converterCollection;
         private readonly IEntityIdentityService _identityService;
+        private readonly IUmbracoContextFactory _umbracoContextFactory;
 
-        public EnterspeedPropertyService(EnterspeedPropertyValueConverterCollection converterCollection)
+        public EnterspeedPropertyService(
+            EnterspeedPropertyValueConverterCollection converterCollection,
+            IUmbracoContextFactory umbracoContextFactory)
         {
             _converterCollection = converterCollection;
+            _umbracoContextFactory = umbracoContextFactory;
             _identityService = Current.Factory.GetInstance<IEntityIdentityService>();
         }
 
@@ -27,9 +32,27 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             var properties = content.Properties;
             var enterspeedProperties = ConvertProperties(properties, culture);
 
-            enterspeedProperties.Add(MetaData, CreateMetaData(content, culture));
+            enterspeedProperties.Add(MetaData, CreateNodeMetaData(content, culture));
 
             return enterspeedProperties;
+        }
+
+        private IEnterspeedProperty CreateNodeMetaData(IPublishedContent content, string culture)
+        {
+            var metaData = new Dictionary<string, IEnterspeedProperty>
+            {
+                ["name"] = new StringEnterspeedProperty("name", content.Name(culture)),
+                ["culture"] = new StringEnterspeedProperty("culture", culture),
+                ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
+                ["level"] = new NumberEnterspeedProperty("level", content.Level),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
+            };
+
+            MapAdditionalMetaData(metaData, content, culture);
+
+            return new ObjectEnterspeedProperty("metaData", metaData);
         }
 
         public IDictionary<string, IEnterspeedProperty> ConvertProperties(IEnumerable<IPublishedProperty> properties, string culture = null)
@@ -75,7 +98,25 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
 
         public IDictionary<string, IEnterspeedProperty> GetProperties(IMedia media)
         {
-            var enterspeedProperties = new Dictionary<string, IEnterspeedProperty>
+            using (var context = _umbracoContextFactory.EnsureUmbracoContext())
+            {
+                var publishedMedia = context.UmbracoContext.Media?.GetById(media.Id);
+                if (publishedMedia == null)
+                {
+                    return null;
+                }
+
+                var properties = publishedMedia.Properties.Where(p => !p.Alias.Equals(Constants.Conventions.Media.File));
+                var enterspeedProperties = ConvertProperties(properties);
+                enterspeedProperties.Add(MetaData, CreateMediaMetaProperties(media, publishedMedia));
+
+                return enterspeedProperties;
+            }
+        }
+
+        private ObjectEnterspeedProperty CreateMediaMetaProperties(IMedia media, IPublishedContent publishedMedia)
+        {
+            var metaData = new Dictionary<string, IEnterspeedProperty>
             {
                 { "name", new StringEnterspeedProperty("name", media.Name) },
                 { "size", new StringEnterspeedProperty("size", media.GetValue<string>("umbracoBytes")) },
@@ -89,25 +130,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
                 { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
             };
 
-            return enterspeedProperties;
-        }
+            MapAdditionalMetaData(metaData, publishedMedia, string.Empty);
 
-        private IEnterspeedProperty CreateMetaData(IPublishedContent content, string culture)
-        {
-            var metaData = new Dictionary<string, IEnterspeedProperty>
-            {
-                ["name"] = new StringEnterspeedProperty("name", content.Name(culture)),
-                ["culture"] = new StringEnterspeedProperty("culture", culture),
-                ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
-                ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
-            };
-
-            MapAdditionalMetaData(metaData, content, culture);
-
-            return new ObjectEnterspeedProperty("metaData", metaData);
+            var metaProperties = new ObjectEnterspeedProperty(MetaData, metaData);
+            return metaProperties;
         }
 
         /// <summary>

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedPropertyService.cs
@@ -34,9 +34,27 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
             var properties = content.Properties;
             var enterspeedProperties = ConvertProperties(properties, culture);
 
-            enterspeedProperties.Add(MetaData, CreateMetaData(content, culture));
+            enterspeedProperties.Add(MetaData, CreateNodeMetaData(content, culture));
 
             return enterspeedProperties;
+        }
+        
+        private IEnterspeedProperty CreateNodeMetaData(IPublishedContent content, string culture)
+        {
+            var metaData = new Dictionary<string, IEnterspeedProperty>
+            {
+                ["name"] = new StringEnterspeedProperty("name", content.Name(culture)),
+                ["culture"] = new StringEnterspeedProperty("culture", culture),
+                ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
+                ["level"] = new NumberEnterspeedProperty("level", content.Level),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
+            };
+
+            MapAdditionalMetaData(metaData, content, culture);
+
+            return new ObjectEnterspeedProperty("metaData", metaData);
         }
 
         public IDictionary<string, IEnterspeedProperty> ConvertProperties(IEnumerable<IPublishedProperty> properties, string culture = null)
@@ -115,24 +133,6 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
 
             var metaProperties = new ObjectEnterspeedProperty(MetaData, metaData);
             return metaProperties;
-        }
-
-        private IEnterspeedProperty CreateMetaData(IPublishedContent content, string culture)
-        {
-            var metaData = new Dictionary<string, IEnterspeedProperty>
-            {
-                ["name"] = new StringEnterspeedProperty("name", content.Name(culture)),
-                ["culture"] = new StringEnterspeedProperty("culture", culture),
-                ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
-                ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
-            };
-
-            MapAdditionalMetaData(metaData, content, culture);
-
-            return new ObjectEnterspeedProperty("metaData", metaData);
         }
 
         /// <summary>

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedPropertyService.cs
@@ -4,6 +4,7 @@ using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V9.DataPropertyValueConverters;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Models;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -18,14 +19,17 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
         private readonly EnterspeedPropertyValueConverterCollection _converterCollection;
         private readonly IEntityIdentityService _identityService;
         private readonly IUmbracoContextFactory _umbracoContextFactory;
+        private readonly ILogger<EnterspeedPropertyService> _logger;
 
         public EnterspeedPropertyService(
             EnterspeedPropertyValueConverterCollection converterCollection,
             IServiceProvider serviceProvider,
-            IUmbracoContextFactory umbracoContextFactory)
+            IUmbracoContextFactory umbracoContextFactory,
+            ILogger<EnterspeedPropertyService> logger)
         {
             _converterCollection = converterCollection;
             _umbracoContextFactory = umbracoContextFactory;
+            _logger = logger;
             _identityService = serviceProvider.GetRequiredService<IEntityIdentityService>();
         }
 
@@ -38,7 +42,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
 
             return enterspeedProperties;
         }
-        
+
         private IEnterspeedProperty CreateNodeMetaData(IPublishedContent content, string culture)
         {
             var metaData = new Dictionary<string, IEnterspeedProperty>
@@ -102,11 +106,20 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
         {
             using (var context = _umbracoContextFactory.EnsureUmbracoContext())
             {
-                var publishedMedia = context.UmbracoContext.Media?.GetById(media.Id);
-                if (publishedMedia == null) return null;
+                IDictionary<string, IEnterspeedProperty> enterspeedProperties;
 
-                var properties = publishedMedia.Properties.Where(p => !p.Alias.Equals(Constants.Conventions.Media.File));
-                var enterspeedProperties = ConvertProperties(properties);
+                var publishedMedia = context.UmbracoContext.Media?.GetById(media.Id);
+                if (publishedMedia != null)
+                {
+                    var properties = publishedMedia.Properties.Where(p => !p.Alias.Equals(Constants.Conventions.Media.File));
+                    enterspeedProperties = ConvertProperties(properties);
+                }
+                else
+                {
+                    _logger.LogWarning($"Could not get media as published content, for media with id of {media.Id}");
+                    enterspeedProperties = new Dictionary<string, IEnterspeedProperty>();
+                }
+
                 enterspeedProperties.Add(MetaData, CreateMediaMetaProperties(media, publishedMedia));
 
                 return enterspeedProperties;


### PR DESCRIPTION
- Implemented custom properties on media.

There is a slight change in the structure in the source as well. I found out that we didn't implement a meta object for the generic properties, they were all in the root. 

We went from 
```
	"properties": {
		"coolCustomProperty": "",
		"name": "Knitted West",
		"size": "602717",
		"type": "jpg",
		"width": "683",
		"height": "1024",
		"path": "-1,1141,1149",
		"createDate": "2022-09-05T15:48:37",
		"updateDate": "2022-09-28T18:07:07",
		"level": 2,
		"nodePath": [
			"1141",
			"1149"
		]
	}
```

to 
```
	"properties": {
		"coolCustomProperty": "",
		"metaData": {
			"name": "Knitted West",
			"size": "602717",
			"type": "jpg",
			"width": "683",
			"height": "1024",
			"path": "-1,1141,1149",
			"createDate": "2022-09-05T15:48:37",
			"updateDate": "2022-09-28T18:07:07",
			"level": 2,
			"nodePath": [
				"1141",
				"1149"
			]
		}
	}
```

I will have a talk with Rene about this.