### PR TITLE
Changed output format for DefaultDateTimePropertyValueConverter for Umbraco 10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,15 @@
 
 All notable changes to this project will be documented in this file.
 
-The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+### Breaking changes
+- Changed output of `DefaultDateTimePropertyValueConverter` from `date.ToString(CultureInfo.InvariantCulture))` to `date.ToString("yyyy-MM-ddTHH:mm:ss"))` (Umbraco 10)
+  
+  This is done to make the default version sortable and to match the format of other date fields like `createDate` and `updateDate`
+  
+  If you are using `DefaultDateTimePropertyValueConverter` and this change will break you project, simply override it with your own implementation.
 
 ## [0.15.4 - 2022-09-30]
 - Changed structure on media metadata properties

--- a/src/Enterspeed.Source.UmbracoCms.V10/Extensions/DateTimeExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,14 @@
+﻿using System;
+
+namespace Enterspeed.Source.UmbracoCms.V10.Extensions;
+
+public static class DateTimeExtensions
+{
+    /// <summary>
+    /// Converts a <see cref="DateTime"/> object to a string with the following format: yyyy-MM-ddTHH:mm:ss.
+    /// </summary>
+    public static string ToEnterspeedFormatString(this DateTime dateTime)
+    {
+        return dateTime.ToString("yyyy-MM-ddTHH:mm:ss");
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultDateTimePropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultDateTimePropertyValueConverter.cs
@@ -1,5 +1,4 @@
 ﻿using System;
-using System.Globalization;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V10.Extensions;
 using Umbraco.Cms.Core.Models.PublishedContent;
@@ -16,7 +15,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
         public virtual IEnterspeedProperty Convert(IPublishedProperty property, string culture)
         {
             var date = property.GetValue<DateTime>(culture);
-            return new StringEnterspeedProperty(property.Alias, date.ToString(CultureInfo.InvariantCulture));
+            return new StringEnterspeedProperty(property.Alias, date.ToString("yyyy-MM-ddTHH:mm:ss"));
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultDateTimePropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultDateTimePropertyValueConverter.cs
@@ -15,7 +15,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
         public virtual IEnterspeedProperty Convert(IPublishedProperty property, string culture)
         {
             var date = property.GetValue<DateTime>(culture);
-            return new StringEnterspeedProperty(property.Alias, date.ToString("yyyy-MM-ddTHH:mm:ss"));
+            return new StringEnterspeedProperty(property.Alias, date.ToEnterspeedFormatString());
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/EnterspeedPropertyService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V10.DataPropertyValueConverters;
+using Enterspeed.Source.UmbracoCms.V10.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
@@ -51,8 +52,8 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services
                 ["culture"] = new StringEnterspeedProperty("culture", culture),
                 ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
                 ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToEnterspeedFormatString()),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToEnterspeedFormatString()),
                 ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
             };
 
@@ -132,8 +133,8 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services
             {
                 { "name", new StringEnterspeedProperty("name", media.Name) },
                 { "path", new StringEnterspeedProperty("path", media.Path) },
-                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
-                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToEnterspeedFormatString()) },
+                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToEnterspeedFormatString()) },
                 { "level", new NumberEnterspeedProperty("level", media.Level) },
                 { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
             };

--- a/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Enterspeed.Source.UmbracoCms.V7.csproj
@@ -258,6 +258,7 @@
     <Compile Include="EventHandlers\DictionaryEventHandler.cs" />
     <Compile Include="Extensions\ContentBaseExtensions.cs" />
     <Compile Include="Extensions\ContentExtensions.cs" />
+    <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Extensions\EnterspeedConfigurationExtensions.cs" />
     <Compile Include="Extensions\MediaExtensions.cs" />
     <Compile Include="Extensions\UrlStringExtensions.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V7/Extensions/DateTimeExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Enterspeed.Source.UmbracoCms.V7.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="DateTime"/> object to a string with the following format: yyyy-MM-ddTHH:mm:ss.
+        /// </summary>
+        public static string ToEnterspeedFormatString(this DateTime dateTime)
+        {
+            return dateTime.ToString("yyyy-MM-ddTHH:mm:ss");
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Services/EnterspeedPropertyService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V7.Contexts;
+using Enterspeed.Source.UmbracoCms.V7.Extensions;
 using Enterspeed.Source.UmbracoCms.V7.Models;
 using Enterspeed.Source.UmbracoCms.V7.Services.DataProperties;
 using Umbraco.Core;
@@ -114,8 +115,8 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services
             {
                 { "name", new StringEnterspeedProperty("name", media.Name) },
                 { "path", new StringEnterspeedProperty("path", media.Path) },
-                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
-                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToEnterspeedFormatString()) },
+                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToEnterspeedFormatString()) },
                 { "level", new NumberEnterspeedProperty("level", media.Level) },
                 { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
             };
@@ -140,8 +141,8 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services
                 ["culture"] = new StringEnterspeedProperty("culture", content.GetCulture().IetfLanguageTag.ToLowerInvariant()),
                 ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
                 ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToEnterspeedFormatString()),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.UpdateDate.ToEnterspeedFormatString()),
                 ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path))
             };
 

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -304,6 +304,7 @@
     <Compile Include="EventHandlers\EnterspeedMediaItemSavedEventHandler.cs" />
     <Compile Include="EventHandlers\EnterspeedDictionaryItemSavedEventHandler.cs" />
     <Compile Include="Exceptions\JobHandlingException.cs" />
+    <Compile Include="Extensions\DateTimeExtensions.cs" />
     <Compile Include="Extensions\EnterspeedConfigurationExtensions.cs" />
     <Compile Include="Extensions\MediaExtensions.cs" />
     <Compile Include="Extensions\PropertyExtensions.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Extensions/DateTimeExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="DateTime"/> object to a string with the following format: yyyy-MM-ddTHH:mm:ss.
+        /// </summary>
+        public static string ToEnterspeedFormatString(this DateTime dateTime)
+        {
+            return dateTime.ToString("yyyy-MM-ddTHH:mm:ss");
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/EnterspeedPropertyService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V8.Components.DataPropertyValueConverter;
+using Enterspeed.Source.UmbracoCms.V8.Extensions;
 using Umbraco.Core;
 using Umbraco.Core.Composing;
 using Umbraco.Core.Logging;
@@ -49,8 +50,8 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
                 ["culture"] = new StringEnterspeedProperty("culture", culture),
                 ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
                 ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToEnterspeedFormatString()),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToEnterspeedFormatString()),
                 ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
             };
 
@@ -124,15 +125,14 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services
             }
         }
 
-
         private ObjectEnterspeedProperty CreateMediaProperties(IMedia media, IPublishedContent publishedMedia)
         {
             var metaData = new Dictionary<string, IEnterspeedProperty>
             {
                 { "name", new StringEnterspeedProperty("name", media.Name) },
                 { "path", new StringEnterspeedProperty("path", media.Path) },
-                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
-                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToEnterspeedFormatString()) },
+                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToEnterspeedFormatString()) },
                 { "level", new NumberEnterspeedProperty("level", media.Level) },
                 { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
             };

--- a/src/Enterspeed.Source.UmbracoCms.V9/Extensions/DateTimeExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Extensions/DateTimeExtensions.cs
@@ -1,0 +1,15 @@
+﻿using System;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Extensions
+{
+    public static class DateTimeExtensions
+    {
+        /// <summary>
+        /// Converts a <see cref="DateTime"/> object to a string with the following format: yyyy-MM-ddTHH:mm:ss.
+        /// </summary>
+        public static string ToEnterspeedFormatString(this DateTime dateTime)
+        {
+            return dateTime.ToString("yyyy-MM-ddTHH:mm:ss");
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedPropertyService.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/EnterspeedPropertyService.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V9.DataPropertyValueConverters;
+using Enterspeed.Source.UmbracoCms.V9.Extensions;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Logging;
 using Umbraco.Cms.Core;
@@ -51,8 +52,8 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
                 ["culture"] = new StringEnterspeedProperty("culture", culture),
                 ["sortOrder"] = new NumberEnterspeedProperty("sortOrder", content.SortOrder),
                 ["level"] = new NumberEnterspeedProperty("level", content.Level),
-                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")),
-                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToString("yyyy-MM-ddTHH:mm:ss")),
+                ["createDate"] = new StringEnterspeedProperty("createDate", content.CreateDate.ToEnterspeedFormatString()),
+                ["updateDate"] = new StringEnterspeedProperty("updateDate", content.CultureDate(culture).ToEnterspeedFormatString()),
                 ["nodePath"] = new ArrayEnterspeedProperty("nodePath", GetNodePath(content.Path, culture))
             };
 
@@ -132,8 +133,8 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services
             {
                 { "name", new StringEnterspeedProperty("name", media.Name) },
                 { "path", new StringEnterspeedProperty("path", media.Path) },
-                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
-                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToString("yyyy-MM-ddTHH:mm:ss")) },
+                { "createDate", new StringEnterspeedProperty("createDate", media.CreateDate.ToEnterspeedFormatString()) },
+                { "updateDate", new StringEnterspeedProperty("updateDate", media.UpdateDate.ToEnterspeedFormatString()) },
                 { "level", new NumberEnterspeedProperty("level", media.Level) },
                 { "nodePath", new ArrayEnterspeedProperty("nodePath", GetNodePath(media)) },
             };


### PR DESCRIPTION
Changed output of  `DefaultDateTimePropertyValueConverter` from `date.ToString(CultureInfo.InvariantCulture))`  to  `date.ToString("yyyy-MM-ddTHH:mm:ss"))`  (Umbraco 10)

This is done to make the default version sortable and to match the format of other date fields like `createDate` and `updateDate`