### PR TITLE
Feature/sc 1834/internal links in umbraco rich text is not parsed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on Keep a Changelog, and this project adheres to Semantic Versioning.
 
+## [Unreleased]
+### Fixed
+- Fixed missing parsing of internal links and media references from rich text editor in Grid layout (Umbraco 8, 9 & 10)
+
 ## [0.15.4 - 2022-09-30]
 - Changed structure on media metadata properties
 

--- a/README.md
+++ b/README.md
@@ -20,6 +20,10 @@ To get started with Enterspeed for Umbraco 8, please see:
 To get started with Enterspeed for Umbraco 7, please see:  
 [Umbraco v7 documentation - Getting started](https://docs.enterspeed.com/integrations/umbraco/umbraco-v7/getting-started/)
 
+## Changelog
+
+See new features, fixes and breaking changes in the [changelog](./CHANGELOG.md).
+
 ## Contributing
 
 Pull requests are very welcome.  

--- a/src/Enterspeed.Source.UmbracoCms.V10/Composers/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Composers/EnterspeedComposer.cs
@@ -63,6 +63,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Composers
             builder.Services.AddSingleton<IEnterspeedConfigurationProvider, EnterspeedUmbracoConfigurationProvider>();
             builder.Services.AddSingleton<IJsonSerializer, SystemTextJsonSerializer>();
             builder.Services.AddSingleton<IEnterspeedConnection, EnterspeedConnection>();
+            builder.Services.AddSingleton<IUmbracoRichTextParser, UmbracoRichTextParser>();
 
             builder.Services.AddSingleton<IEnterspeedConnectionProvider>(
                 c =>

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
@@ -1,18 +1,17 @@
-﻿using System;
-using System.Linq;
-using Enterspeed.Source.Sdk.Api.Models.Properties;
+﻿using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V10.Extensions;
-using HtmlAgilityPack;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConverters
 {
     public class DefaultRichTextEditorPropertyValueConverter : IEnterspeedPropertyValueConverter
     {
+        private readonly IUmbracoRichTextParser _umbracoRichTextParser;
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
 
-        public DefaultRichTextEditorPropertyValueConverter(IEnterspeedConfigurationService enterspeedConfigurationService)
+        public DefaultRichTextEditorPropertyValueConverter(IUmbracoRichTextParser umbracoRichTextParser, IEnterspeedConfigurationService enterspeedConfigurationService)
         {
+            _umbracoRichTextParser = umbracoRichTextParser;
             _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
@@ -24,37 +23,8 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
         public virtual IEnterspeedProperty Convert(IPublishedProperty property, string culture)
         {
             var value = property.GetValue<Umbraco.Cms.Core.Strings.HtmlEncodedString>(culture).ToString();
-            value = PrefixRelativeImagesWithDomain(value, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
+            value = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(value, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
             return new StringEnterspeedProperty(property.Alias, value);
-        }
-
-        private string PrefixRelativeImagesWithDomain(string html, string mediaDomain)
-        {
-            if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(mediaDomain))
-            {
-                return html;
-            }
-
-            var htmlDocument = new HtmlDocument();
-            htmlDocument.LoadHtml(html);
-
-            var imageNodes = htmlDocument.DocumentNode.SelectNodes("//img");
-            if (imageNodes == null || !imageNodes.Any())
-            {
-                return html;
-            }
-
-            var mediaDomainUrl = new Uri(mediaDomain);
-            foreach (var imageNode in imageNodes)
-            {
-                var src = imageNode.GetAttributeValue("src", string.Empty);
-                if (src.StartsWith("/media/"))
-                {
-                    imageNode.SetAttributeValue("src", new Uri(mediaDomainUrl, src).ToString());
-                }
-            }
-
-            return htmlDocument.DocumentNode.InnerHtml;
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
@@ -6,6 +6,15 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultGridCo
 {
     public class DefaultRichTextEditorGridEditorValueConverter : IEnterspeedGridEditorValueConverter
     {
+        private readonly IUmbracoRichTextParser _umbracoRichTextParser;
+        private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
+
+        public DefaultRichTextEditorGridEditorValueConverter(IUmbracoRichTextParser umbracoRichTextParser, IEnterspeedConfigurationService enterspeedConfigurationService)
+        {
+            _umbracoRichTextParser = umbracoRichTextParser;
+            _enterspeedConfigurationService = enterspeedConfigurationService;
+        }
+
         public bool IsConverter(string alias)
         {
             return alias.InvariantEquals("rte");
@@ -13,7 +22,10 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultGridCo
 
         public virtual IEnterspeedProperty Convert(GridControl editor, string culture)
         {
-            return new StringEnterspeedProperty(editor.Value.ToString());
+            var parsedHtmlString = _umbracoRichTextParser.ParseInternalLink(editor.Value.ToString());
+            parsedHtmlString = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(parsedHtmlString, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
+
+            return new StringEnterspeedProperty(parsedHtmlString);
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/IUmbracoRichTextParser.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/IUmbracoRichTextParser.cs
@@ -1,0 +1,7 @@
+﻿namespace Enterspeed.Source.UmbracoCms.V10.Services;
+
+public interface IUmbracoRichTextParser
+{
+    string ParseInternalLink(string htmlValue);
+    string PrefixRelativeImagesWithDomain(string html, string mediaDomain);
+}

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/UmbracoRichTextParser.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/UmbracoRichTextParser.cs
@@ -1,0 +1,55 @@
+﻿using System;
+using System.Linq;
+using HtmlAgilityPack;
+using Umbraco.Cms.Core.Templates;
+
+namespace Enterspeed.Source.UmbracoCms.V10.Services;
+
+public class UmbracoRichTextParser : IUmbracoRichTextParser
+{
+    private readonly HtmlLocalLinkParser _htmlLocalLinkParser;
+    private readonly HtmlImageSourceParser _htmlImageSourceParser;
+
+    public UmbracoRichTextParser(HtmlLocalLinkParser htmlLocalLinkParser, HtmlImageSourceParser htmlImageSourceParser)
+    {
+        _htmlLocalLinkParser = htmlLocalLinkParser;
+        _htmlImageSourceParser = htmlImageSourceParser;
+    }
+
+    public string ParseInternalLink(string htmlValue)
+    {
+        var parsedHtmlValue = _htmlLocalLinkParser.EnsureInternalLinks(htmlValue);
+        parsedHtmlValue = _htmlImageSourceParser.EnsureImageSources(parsedHtmlValue);
+
+        return parsedHtmlValue;
+    }
+
+    public string PrefixRelativeImagesWithDomain(string html, string mediaDomain)
+    {
+        if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(mediaDomain))
+        {
+            return html;
+        }
+
+        var htmlDocument = new HtmlDocument();
+        htmlDocument.LoadHtml(html);
+
+        var imageNodes = htmlDocument.DocumentNode.SelectNodes("//img");
+        if (imageNodes == null || !imageNodes.Any())
+        {
+            return html;
+        }
+
+        var mediaDomainUrl = new Uri(mediaDomain);
+        foreach (var imageNode in imageNodes)
+        {
+            var src = imageNode.GetAttributeValue("src", string.Empty);
+            if (src.StartsWith("/media/"))
+            {
+                imageNode.SetAttributeValue("src", new Uri(mediaDomainUrl, src).ToString());
+            }
+        }
+
+        return htmlDocument.DocumentNode.InnerHtml;
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V7/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V7.Contexts;
 using Enterspeed.Source.UmbracoCms.V7.Providers;

--- a/src/Enterspeed.Source.UmbracoCms.V7/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
@@ -1,5 +1,4 @@
-﻿using System;
-using System.Linq;
+﻿using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V7.Contexts;
 using Enterspeed.Source.UmbracoCms.V7.Models.Grid;

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/EnterspeedComposer.cs
@@ -59,6 +59,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components
             composition.Register<IEnterspeedJobFactory, EnterspeedJobFactory>(Lifetime.Request);
             composition.Register<IEnterspeedJobsHandler, EnterspeedJobsHandler>(Lifetime.Transient);
             composition.Register<IEnterspeedJobsHandlingService, EnterspeedJobsHandlingService>(Lifetime.Transient);
+            composition.Register<IUmbracoRichTextParser, UmbracoRichTextParser>(Lifetime.Singleton);
 
             composition.Register<IEnterspeedConnection>(
                 c =>

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -400,10 +400,12 @@
     <Compile Include="Services\IEntityIdentityService.cs" />
     <Compile Include="Services\IUmbracoRedirectsService.cs" />
     <Compile Include="Services\IUmbracoContextProvider.cs" />
+    <Compile Include="Services\IUmbracoRichTextParser.cs" />
     <Compile Include="Services\IUmbracoUrlService.cs" />
     <Compile Include="Services\UmbracoRedirectsService.cs" />
     <Compile Include="Services\UmbracoContextProvider.cs" />
     <Compile Include="Services\UmbracoEntityIdentityService.cs" />
+    <Compile Include="Services\UmbracoRichTextParser.cs" />
     <Compile Include="Services\UmbracoUrlService.cs" />
   </ItemGroup>
   <ItemGroup>

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
@@ -6,6 +6,15 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultGridCon
 {
     public class DefaultRichTextEditorGridEditorValueConverter : IEnterspeedGridEditorValueConverter
     {
+        private readonly IUmbracoRichTextParser _umbracoRichTextParser;
+        private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
+
+        public DefaultRichTextEditorGridEditorValueConverter(IUmbracoRichTextParser umbracoRichTextParser, IEnterspeedConfigurationService enterspeedConfigurationService)
+        {
+            _umbracoRichTextParser = umbracoRichTextParser;
+            _enterspeedConfigurationService = enterspeedConfigurationService;
+        }
+
         public bool IsConverter(string alias)
         {
             return alias.InvariantEquals("rte");
@@ -13,7 +22,10 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultGridCon
 
         public IEnterspeedProperty Convert(GridControl editor, string culture)
         {
-            return new StringEnterspeedProperty(editor.Value.ToString());
+            var parsedHtmlString = _umbracoRichTextParser.ParseInternalLink(editor.Value.ToString());
+            parsedHtmlString = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(parsedHtmlString, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
+
+            return new StringEnterspeedProperty(parsedHtmlString);
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/IUmbracoRichTextParser.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/IUmbracoRichTextParser.cs
@@ -1,0 +1,8 @@
+﻿namespace Enterspeed.Source.UmbracoCms.V8.Services
+{
+    public interface IUmbracoRichTextParser
+    {
+        string ParseInternalLink(string htmlValue);
+        string PrefixRelativeImagesWithDomain(string html, string mediaDomain);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/UmbracoRichTextParser.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/UmbracoRichTextParser.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using HtmlAgilityPack;
+using Umbraco.Web.Templates;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Services
+{
+    public class UmbracoRichTextParser : IUmbracoRichTextParser
+    {
+        private readonly HtmlLocalLinkParser _htmlLocalLinkParser;
+        private readonly HtmlImageSourceParser _htmlImageSourceParser;
+
+        public UmbracoRichTextParser(HtmlLocalLinkParser htmlLocalLinkParser, HtmlImageSourceParser htmlImageSourceParser)
+        {
+            _htmlLocalLinkParser = htmlLocalLinkParser;
+            _htmlImageSourceParser = htmlImageSourceParser;
+        }
+
+        public string ParseInternalLink(string htmlValue)
+        {
+            var parsedHtmlValue = _htmlLocalLinkParser.EnsureInternalLinks(htmlValue);
+            parsedHtmlValue = _htmlImageSourceParser.EnsureImageSources(parsedHtmlValue);
+
+            return parsedHtmlValue;
+        }
+
+        public string PrefixRelativeImagesWithDomain(string html, string mediaDomain)
+        {
+            if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(mediaDomain))
+            {
+                return html;
+            }
+
+            var htmlDocument = new HtmlDocument();
+            htmlDocument.LoadHtml(html);
+
+            var imageNodes = htmlDocument.DocumentNode.SelectNodes("//img");
+            if (imageNodes == null || !imageNodes.Any())
+            {
+                return html;
+            }
+
+            var mediaDomainUrl = new Uri(mediaDomain);
+            foreach (var imageNode in imageNodes)
+            {
+                var src = imageNode.GetAttributeValue("src", string.Empty);
+                if (src.StartsWith("/media/"))
+                {
+                    imageNode.SetAttributeValue("src", new Uri(mediaDomainUrl, src).ToString());
+                }
+            }
+
+            return htmlDocument.DocumentNode.InnerHtml;
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Composers/EnterspeedComposer.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Composers/EnterspeedComposer.cs
@@ -63,6 +63,7 @@ namespace Enterspeed.Source.UmbracoCms.V9.Composers
             builder.Services.AddSingleton<IEnterspeedConfigurationProvider, EnterspeedUmbracoConfigurationProvider>();
             builder.Services.AddSingleton<IJsonSerializer, SystemTextJsonSerializer>();
             builder.Services.AddSingleton<IEnterspeedConnection, EnterspeedConnection>();
+            builder.Services.AddSingleton<IUmbracoRichTextParser, UmbracoRichTextParser>();
 
             builder.Services.AddSingleton<IEnterspeedConnectionProvider>(
                 c =>

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
@@ -1,19 +1,17 @@
-﻿using System;
-using System.Linq;
-using Enterspeed.Source.Sdk.Api.Models.Properties;
+﻿using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.V9.Extensions;
-using HtmlAgilityPack;
-using Microsoft.AspNetCore.Html;
 using Umbraco.Cms.Core.Models.PublishedContent;
 
 namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConverters
 {
     public class DefaultRichTextEditorPropertyValueConverter : IEnterspeedPropertyValueConverter
     {
+        private readonly IUmbracoRichTextParser _umbracoRichTextParser;
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
 
-        public DefaultRichTextEditorPropertyValueConverter(IEnterspeedConfigurationService enterspeedConfigurationService)
+        public DefaultRichTextEditorPropertyValueConverter(IUmbracoRichTextParser umbracoRichTextParser, IEnterspeedConfigurationService enterspeedConfigurationService)
         {
+            _umbracoRichTextParser = umbracoRichTextParser;
             _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
@@ -25,37 +23,8 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
         public IEnterspeedProperty Convert(IPublishedProperty property, string culture)
         {
             var value = property.GetValue<Umbraco.Cms.Core.Strings.HtmlEncodedString>(culture).ToString();
-            value = PrefixRelativeImagesWithDomain(value, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
+            value = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(value, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
             return new StringEnterspeedProperty(property.Alias, value);
-        }
-
-        private string PrefixRelativeImagesWithDomain(string html, string mediaDomain)
-        {
-            if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(mediaDomain))
-            {
-                return html;
-            }
-
-            var htmlDocument = new HtmlDocument();
-            htmlDocument.LoadHtml(html);
-
-            var imageNodes = htmlDocument.DocumentNode.SelectNodes("//img");
-            if (imageNodes == null || !imageNodes.Any())
-            {
-                return html;
-            }
-
-            var mediaDomainUrl = new Uri(mediaDomain);
-            foreach (var imageNode in imageNodes)
-            {
-                var src = imageNode.GetAttributeValue("src", string.Empty);
-                if (src.StartsWith("/media/"))
-                {
-                    imageNode.SetAttributeValue("src", new Uri(mediaDomainUrl, src).ToString());
-                }
-            }
-
-            return htmlDocument.DocumentNode.InnerHtml;
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultGridConverters/DefaultRichTextEditorGridEditorValueConverter.cs
@@ -6,6 +6,15 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultGridCon
 {
     public class DefaultRichTextEditorGridEditorValueConverter : IEnterspeedGridEditorValueConverter
     {
+        private readonly IUmbracoRichTextParser _umbracoRichTextParser;
+        private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
+
+        public DefaultRichTextEditorGridEditorValueConverter(IUmbracoRichTextParser umbracoRichTextParser, IEnterspeedConfigurationService enterspeedConfigurationService)
+        {
+            _umbracoRichTextParser = umbracoRichTextParser;
+            _enterspeedConfigurationService = enterspeedConfigurationService;
+        }
+
         public bool IsConverter(string alias)
         {
             return alias.InvariantEquals("rte");
@@ -13,7 +22,10 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultGridCon
 
         public IEnterspeedProperty Convert(GridControl editor, string culture)
         {
-            return new StringEnterspeedProperty(editor.Value.ToString());
+            var parsedHtmlString = _umbracoRichTextParser.ParseInternalLink(editor.Value.ToString());
+            parsedHtmlString = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(parsedHtmlString, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
+
+            return new StringEnterspeedProperty(parsedHtmlString);
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/IUmbracoRichTextParser.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/IUmbracoRichTextParser.cs
@@ -1,0 +1,8 @@
+﻿namespace Enterspeed.Source.UmbracoCms.V9.Services
+{
+    public interface IUmbracoRichTextParser
+    {
+        string ParseInternalLink(string htmlValue);
+        string PrefixRelativeImagesWithDomain(string html, string mediaDomain);
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/UmbracoRichTextParser.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/UmbracoRichTextParser.cs
@@ -1,0 +1,56 @@
+﻿using System;
+using System.Linq;
+using HtmlAgilityPack;
+using Umbraco.Cms.Core.Templates;
+
+namespace Enterspeed.Source.UmbracoCms.V9.Services
+{
+    public class UmbracoRichTextParser : IUmbracoRichTextParser
+    {
+        private readonly HtmlLocalLinkParser _htmlLocalLinkParser;
+        private readonly HtmlImageSourceParser _htmlImageSourceParser;
+
+        public UmbracoRichTextParser(HtmlLocalLinkParser htmlLocalLinkParser, HtmlImageSourceParser htmlImageSourceParser)
+        {
+            _htmlLocalLinkParser = htmlLocalLinkParser;
+            _htmlImageSourceParser = htmlImageSourceParser;
+        }
+
+        public string ParseInternalLink(string htmlValue)
+        {
+            var parsedHtmlValue = _htmlLocalLinkParser.EnsureInternalLinks(htmlValue);
+            parsedHtmlValue = _htmlImageSourceParser.EnsureImageSources(parsedHtmlValue);
+
+            return parsedHtmlValue;
+        }
+
+        public string PrefixRelativeImagesWithDomain(string html, string mediaDomain)
+        {
+            if (string.IsNullOrWhiteSpace(html) || string.IsNullOrWhiteSpace(mediaDomain))
+            {
+                return html;
+            }
+
+            var htmlDocument = new HtmlDocument();
+            htmlDocument.LoadHtml(html);
+
+            var imageNodes = htmlDocument.DocumentNode.SelectNodes("//img");
+            if (imageNodes == null || !imageNodes.Any())
+            {
+                return html;
+            }
+
+            var mediaDomainUrl = new Uri(mediaDomain);
+            foreach (var imageNode in imageNodes)
+            {
+                var src = imageNode.GetAttributeValue("src", string.Empty);
+                if (src.StartsWith("/media/"))
+                {
+                    imageNode.SetAttributeValue("src", new Uri(mediaDomainUrl, src).ToString());
+                }
+            }
+
+            return htmlDocument.DocumentNode.InnerHtml;
+        }
+    }
+}


### PR DESCRIPTION
Fixed missing parsing of internal links and media references from rich text editor in Grid layout (Umbraco 8, 9 & 10)