### PR TITLE
fix: Color Picker Value reference null exception

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultColorPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultColorPickerPropertyValueConverter.cs
@@ -23,8 +23,11 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
             if (UseLabel(property.PropertyType))
             {
                 var colorPickerValue = property.GetValue<ColorPickerValueConverter.PickedColor>(culture);
-                colorValue = colorPickerValue.Color;
-                colorLabel = colorPickerValue.Label;
+                if (colorPickerValue is not null)
+                {
+                    colorValue = colorPickerValue.Color;
+                    colorLabel = colorPickerValue.Label;
+                }
             }
             else
             {

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultColorPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultColorPickerPropertyValueConverter.cs
@@ -23,8 +23,11 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultConvert
             if (UseLabel(property.PropertyType))
             {
                 var colorPickerValue = property.GetValue<ColorPickerValueConverter.PickedColor>(culture);
-                colorValue = colorPickerValue.Color;
-                colorLabel = colorPickerValue.Label;
+                if (colorPickerValue != null)
+                {
+                    colorValue = colorPickerValue.Color;
+                    colorLabel = colorPickerValue.Label;
+                }
             }
             else
             {

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultColorPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultColorPickerPropertyValueConverter.cs
@@ -23,8 +23,11 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
             if (UseLabel(property.PropertyType))
             {
                 var colorPickerValue = property.GetValue<ColorPickerValueConverter.PickedColor>(culture);
-                colorValue = colorPickerValue.Color;
-                colorLabel = colorPickerValue.Label;
+                if (colorPickerValue is not null)
+                {
+                    colorValue = colorPickerValue.Color;
+                    colorLabel = colorPickerValue.Label;
+                }
             }
             else
             {


### PR DESCRIPTION
Added protection for null reference color picker value. This is for case if we don't have assigned property.