### PR TITLE
Fixed Umbraco install error when Enterspeed plugin is installed (Umbraco 9 & 10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Fixed
+  - Fixed Umbraco install error when Enterspeed plugin is installed (Umbraco 9 & 10)
+
 ## [2.0.1 - 2022-10-26]
 ### Added
   - Logging errors instead of responsemessage when ingest throws an error (Umbraco 7, 8, 9 & 10)

--- a/src/Enterspeed.Source.UmbracoCms.V10/Components/EnterspeedJobsComponent.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Components/EnterspeedJobsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Enterspeed.Source.UmbracoCms.V10.Data.Migration;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Migrations;
 using Umbraco.Cms.Core.Services;
@@ -13,19 +14,25 @@ namespace Enterspeed.Source.UmbracoCms.V10.Components
         private readonly IScopeProvider _scopeProvider;
         private readonly IKeyValueService _keyValueService;
         private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+        private readonly IRuntimeState _runtimeState;
 
         public EnterspeedJobsComponent(
             IScopeProvider scopeProvider,
             IKeyValueService keyValueService,
-            IMigrationPlanExecutor migrationPlanExecutor)
+            IMigrationPlanExecutor migrationPlanExecutor,
+            IRuntimeState runtimeState)
         {
             _scopeProvider = scopeProvider;
             _keyValueService = keyValueService;
             _migrationPlanExecutor = migrationPlanExecutor;
+            _runtimeState = runtimeState;
         }
 
         public void Initialize()
         {
+            if (_runtimeState.Level < RuntimeLevel.Run)
+                return;
+
             var migrationPlan = new MigrationPlan("EnterspeedJobs");
             migrationPlan.From(string.Empty)
                 .To<EnterspeedJobsTableMigration>("enterspeedjobs-db")

--- a/src/Enterspeed.Source.UmbracoCms.V9/Components/EnterspeedJobsComponent.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Components/EnterspeedJobsComponent.cs
@@ -1,4 +1,5 @@
 ﻿using Enterspeed.Source.UmbracoCms.V9.Data.Migration;
+using Umbraco.Cms.Core;
 using Umbraco.Cms.Core.Composing;
 using Umbraco.Cms.Core.Migrations;
 using Umbraco.Cms.Core.Scoping;
@@ -13,19 +14,25 @@ namespace Enterspeed.Source.UmbracoCms.V9.Components
         private readonly IScopeProvider _scopeProvider;
         private readonly IKeyValueService _keyValueService;
         private readonly IMigrationPlanExecutor _migrationPlanExecutor;
+        private readonly IRuntimeState _runtimeState;
 
         public EnterspeedJobsComponent(
             IScopeProvider scopeProvider,
             IKeyValueService keyValueService,
-            IMigrationPlanExecutor migrationPlanExecutor)
+            IMigrationPlanExecutor migrationPlanExecutor,
+            IRuntimeState runtimeState)
         {
             _scopeProvider = scopeProvider;
             _keyValueService = keyValueService;
             _migrationPlanExecutor = migrationPlanExecutor;
+            _runtimeState = runtimeState;
         }
 
         public void Initialize()
         {
+            if (_runtimeState.Level < RuntimeLevel.Run)
+                return;
+
             var migrationPlan = new MigrationPlan("EnterspeedJobs");
             migrationPlan.From(string.Empty)
                 .To<EnterspeedJobsTableMigration>("enterspeedjobs-db")


### PR DESCRIPTION
Added runtime level check before running database migrations