### PR TITLE
Logging the full response object when an error happened.

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V10/Handlers/Content/EnterspeedContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Handlers/Content/EnterspeedContentPublishJobHandler.cs
@@ -107,13 +107,11 @@ namespace Enterspeed.Source.UmbracoCms.V10.Handlers.Content
         {
             var ingestResponse = _enterspeedIngestService.Save(umbracoData, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
             if (!ingestResponse.Success)
-            {
-                var message = ingestResponse.Errors != null
-                    ? JsonSerializer.Serialize(ingestResponse.Errors)
-                    : ingestResponse.Message;
+            {   
+                var message = JsonSerializer.Serialize(ingestResponse);
                 throw new JobHandlingException(
                     $"Failed ingesting entity ({job.EntityId}/{job.Culture}). Message: {message}");
-            }  
+            }
         }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Handlers/Dictionaries/EnterspeedDictionaryItemPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Handlers/Dictionaries/EnterspeedDictionaryItemPublishJobHandler.cs
@@ -95,9 +95,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Handlers.Dictionaries
             var ingestResponse = _enterspeedIngestService.Save(umbracoData, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
             if (!ingestResponse.Success)
             {
-                var message = ingestResponse.Errors != null
-                    ? JsonSerializer.Serialize(ingestResponse.Errors)
-                    : ingestResponse.Message;
+                var message = JsonSerializer.Serialize(ingestResponse);
                 throw new JobHandlingException(
                     $"Failed ingesting entity ({job.EntityId}/{job.Culture}). Message: {message}");
             }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -99,9 +99,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Handlers.Media
             var ingestResponse = _enterspeedIngestService.Save(umbracoData, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));
             if (!ingestResponse.Success)
             {
-                var message = ingestResponse.Errors != null
-                    ? JsonSerializer.Serialize(ingestResponse.Errors)
-                    : ingestResponse.Message;
+                var message = JsonSerializer.Serialize(ingestResponse);
                 throw new JobHandlingException(
                     $"Failed ingesting entity ({job.EntityId}/{job.Culture}). Message: {message}");
             }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
@@ -108,9 +108,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Handlers.PreviewContent
                 umbracoData, _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview));
             if (!ingestResponse.Success)
             {
-                var message = ingestResponse.Errors != null
-                    ? JsonSerializer.Serialize(ingestResponse.Errors)
-                    : ingestResponse.Message;
+                var message = JsonSerializer.Serialize(ingestResponse);
                 throw new JobHandlingException(
                     $"Failed ingesting entity ({job.EntityId}/{job.Culture}). Message: {message}");
             }

--- a/src/Enterspeed.Source.UmbracoCms.V10/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemPublishJobHandler.cs
@@ -95,9 +95,7 @@ namespace Enterspeed.Source.UmbracoCms.V10.Handlers.PreviewDictionaries
             var ingestResponse = _enterspeedIngestService.Save(umbracoData, _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview));
             if (!ingestResponse.Success)
             {
-                var message = ingestResponse.Errors != null
-                    ? JsonSerializer.Serialize(ingestResponse.Errors)
-                    : ingestResponse.Message;
+                var message = JsonSerializer.Serialize(ingestResponse);
                 throw new JobHandlingException(
                     $"Failed ingesting entity ({job.EntityId}/{job.Culture}). Message: {message}");
             }


### PR DESCRIPTION
This is done as a temporary fix for the issues we are currently facing. I would like to discuss as well as coordinate with you have we should log this and if the solution is to log the full response when there is an error.

This is only done in V10 for now. When we agree up on the correct strategy, we should implement it across the connectors. 

@emilras @jesperweber 