### PR TITLE
fix: added array value process option

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
@@ -1,4 +1,4 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using Enterspeed.Source.Sdk.Api.Models.Properties;
@@ -55,17 +55,29 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
             var type = value.Type;
             if (type == JTokenType.String)
             {
-                return new StringEnterspeedProperty(name, value.Value<string>());
+                var stringValue = value.Value<string>();
+
+                return !string.IsNullOrEmpty(name)
+                    ? new StringEnterspeedProperty(name, stringValue)
+                    : new StringEnterspeedProperty(stringValue);
             }
 
             if (type == JTokenType.Boolean)
             {
-                return new BooleanEnterspeedProperty(name, value.Value<bool>());
+                var boolValue = value.Value<bool>();
+                
+                return !string.IsNullOrEmpty(name)
+                    ? new BooleanEnterspeedProperty(name, boolValue)
+                    : new BooleanEnterspeedProperty(boolValue);
             }
 
             if (type == JTokenType.Integer)
             {
-                return new NumberEnterspeedProperty(name, value.Value<int>());
+                var numberValue = value.Value<int>();
+                
+                return !string.IsNullOrEmpty(name)
+                    ? new NumberEnterspeedProperty(name, numberValue)
+                    : new NumberEnterspeedProperty(numberValue);
             }
 
             if (type == JTokenType.Array)
@@ -99,6 +111,15 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
                         if (properties.Any())
                         {
                             arrayItems.Add(new ObjectEnterspeedProperty(properties));
+                        }
+                    }
+                    
+                    if (jToken is JValue itemValue)
+                    {
+                        var property = GetProperty(null, itemValue, culture);
+                        if (property is not null)
+                        {
+                            arrayItems.Add(property);
                         }
                     }
                 }

--- a/src/Enterspeed.Source.UmbracoCms.V7/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V7/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
@@ -51,17 +51,38 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services.DataProperties.DefaultConvert
             var type = value.Type;
             if (type == JTokenType.String)
             {
-                return new StringEnterspeedProperty(name, value.Value<string>());
+                var stringValue = value.Value<string>();
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    return new StringEnterspeedProperty(stringValue);
+                }
+
+                return new StringEnterspeedProperty(name, stringValue);
             }
 
             if (type == JTokenType.Boolean)
             {
-                return new BooleanEnterspeedProperty(name, value.Value<bool>());
+                var boolValue = value.Value<bool>();
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    return new BooleanEnterspeedProperty(boolValue);
+                }
+
+                return new BooleanEnterspeedProperty(name, boolValue);
             }
 
             if (type == JTokenType.Integer)
             {
-                return new NumberEnterspeedProperty(name, value.Value<int>());
+                var numberValue = value.Value<int>();
+
+                if (string.IsNullOrEmpty(name))
+                {
+                    return new NumberEnterspeedProperty(numberValue);
+                }
+
+                return new NumberEnterspeedProperty(name, numberValue);
             }
 
             if (type == JTokenType.Array)
@@ -95,6 +116,15 @@ namespace Enterspeed.Source.UmbracoCms.V7.Services.DataProperties.DefaultConvert
                         if (properties.Any())
                         {
                             arrayItems.Add(new ObjectEnterspeedProperty(properties));
+                        }
+                    }
+
+                    if (jToken is JValue itemValue)
+                    {
+                        var property = GetProperty(null, itemValue);
+                        if (property != null)
+                        {
+                            arrayItems.Add(property);
                         }
                     }
                 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
@@ -49,17 +49,29 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultConvert
             var type = value.Type;
             if (type == JTokenType.String)
             {
-                return new StringEnterspeedProperty(name, value.Value<string>());
+                var stringValue = value.Value<string>();
+
+                return !string.IsNullOrEmpty(name)
+                    ? new StringEnterspeedProperty(name, stringValue)
+                    : new StringEnterspeedProperty(stringValue);
             }
 
             if (type == JTokenType.Boolean)
             {
-                return new BooleanEnterspeedProperty(name, value.Value<bool>());
+                var boolValue = value.Value<bool>();
+
+                return !string.IsNullOrEmpty(name)
+                    ? new BooleanEnterspeedProperty(name, boolValue)
+                    : new BooleanEnterspeedProperty(boolValue);
             }
 
             if (type == JTokenType.Integer)
             {
-                return new NumberEnterspeedProperty(name, value.Value<int>());
+                var numberValue = value.Value<int>();
+
+                return !string.IsNullOrEmpty(name)
+                    ? new NumberEnterspeedProperty(name, numberValue)
+                    : new NumberEnterspeedProperty(numberValue);
             }
 
             if (type == JTokenType.Array)
@@ -93,6 +105,15 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultConvert
                         if (properties.Any())
                         {
                             arrayItems.Add(new ObjectEnterspeedProperty(properties));
+                        }
+                    }
+
+                    if (jToken is JValue itemValue)
+                    {
+                        var property = GetProperty(null, itemValue, culture);
+                        if (property != null)
+                        {
+                            arrayItems.Add(property);
                         }
                     }
                 }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultGridLayoutPropertyValueConverter.cs
@@ -55,17 +55,29 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
             var type = value.Type;
             if (type == JTokenType.String)
             {
-                return new StringEnterspeedProperty(name, value.Value<string>());
+                var stringValue = value.Value<string>();
+
+                return !string.IsNullOrEmpty(name)
+                    ? new StringEnterspeedProperty(name, stringValue)
+                    : new StringEnterspeedProperty(stringValue);
             }
 
             if (type == JTokenType.Boolean)
             {
-                return new BooleanEnterspeedProperty(name, value.Value<bool>());
+                var boolValue = value.Value<bool>();
+                
+                return !string.IsNullOrEmpty(name)
+                    ? new BooleanEnterspeedProperty(name, boolValue)
+                    : new BooleanEnterspeedProperty(boolValue);
             }
 
             if (type == JTokenType.Integer)
             {
-                return new NumberEnterspeedProperty(name, value.Value<int>());
+                var numberValue = value.Value<int>();
+                
+                return !string.IsNullOrEmpty(name)
+                    ? new NumberEnterspeedProperty(name, numberValue)
+                    : new NumberEnterspeedProperty(numberValue);
             }
 
             if (type == JTokenType.Array)
@@ -99,6 +111,15 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
                         if (properties.Any())
                         {
                             arrayItems.Add(new ObjectEnterspeedProperty(properties));
+                        }
+                    }
+                    
+                    if (jToken is JValue itemValue)
+                    {
+                        var property = GetProperty(null, itemValue, culture);
+                        if (property is not null)
+                        {
+                            arrayItems.Add(property);
                         }
                     }
                 }


### PR DESCRIPTION
Fixed issue with a missing option for `JArray` values (`JValue`) - currently only supported `JObject`. This made missing data.