### PR TITLE
Fixed DefaultMultiNodeTreePickerPropertyValueConverter when members are selcted

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unreleased]
+### Fixed
+  - DefaultMultiNodeTreePickerPropertyValueConverter throws exception for members as they have no url (Umbraco 8, 9 & 10)
+
 ## [3.0.1 - 2022-11-07]
 ### Added
   - Extended logging information when ingest throws an error (Umbraco 10)

--- a/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V10/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
@@ -88,9 +88,13 @@ namespace Enterspeed.Source.UmbracoCms.V10.Services.DataProperties.DefaultConver
             var properties = new Dictionary<string, IEnterspeedProperty>
             {
                 { "id", new StringEnterspeedProperty(id) },
-                { "name", new StringEnterspeedProperty(node.Name) },
-                { "url", new StringEnterspeedProperty(node.GetUrl(_logger, culture, UrlMode.Absolute)) }
+                { "name", new StringEnterspeedProperty(node.Name) }
             };
+
+            if (node.ContentType.ItemType is PublishedItemType.Content or PublishedItemType.Media)
+            {
+                properties.Add("url", new StringEnterspeedProperty(node.GetUrl(_logger, culture, UrlMode.Absolute)));
+            }
 
             return new ObjectEnterspeedProperty(properties);
         }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
@@ -88,9 +88,13 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultConvert
             var properties = new Dictionary<string, IEnterspeedProperty>
             {
                 { "id", new StringEnterspeedProperty(id) },
-                { "name", new StringEnterspeedProperty(node.Name) },
-                { "url", new StringEnterspeedProperty(node.Url(culture, UrlMode.Absolute)) }
+                { "name", new StringEnterspeedProperty(node.Name) }
             };
+
+            if (node.ContentType.ItemType == PublishedItemType.Content || node.ContentType.ItemType == PublishedItemType.Media)
+            {
+                properties.Add("url", new StringEnterspeedProperty(node.Url(culture, UrlMode.Absolute)));
+            }
 
             return new ObjectEnterspeedProperty(properties);
         }

--- a/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9/Services/DataProperties/DefaultConverters/DefaultMultiNodeTreePickerPropertyValueConverter.cs
@@ -88,9 +88,13 @@ namespace Enterspeed.Source.UmbracoCms.V9.Services.DataProperties.DefaultConvert
             var properties = new Dictionary<string, IEnterspeedProperty>
             {
                 { "id", new StringEnterspeedProperty(id) },
-                { "name", new StringEnterspeedProperty(node.Name) },
-                { "url", new StringEnterspeedProperty(node.GetUrl(_logger, culture, UrlMode.Absolute)) }
+                { "name", new StringEnterspeedProperty(node.Name) }
             };
+
+            if (node.ContentType.ItemType is PublishedItemType.Content or PublishedItemType.Media)
+            {
+                properties.Add("url", new StringEnterspeedProperty(node.GetUrl(_logger, culture, UrlMode.Absolute)));
+            }
 
             return new ObjectEnterspeedProperty(properties);
         }


### PR DESCRIPTION
Members do not have a url so Umbraco throws a `NotSupportedException` when we call `Url()` on a `IPublishedContent `of type `Member`