### PR TITLE
Notify users if Umbraco serverRole is not configured correct

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -5,6 +5,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [Unreleased]
+### Added
+- Added information note on the Enterspeed settings page, if the Umbraco server is running with `ServerRole.Subscriber` as the Enterspeed jobs is only configured to run on servers configured as `ServerRole.SchedulingPublisher` and `ServerRole.Single`. Also upgraded the logging about this from debug to information.
+
 ## [1.1.0 - 2023-01-25]
 ### Added
 - Added support for the new Block grid editor in Umbraco 10.4 and 11

--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.netframework.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.netframework.md
@@ -4,10 +4,15 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+
+## [Unreleased]
+### Added
+- Added information note on the Enterspeed settings page, if the Umbraco server is running with `ServerRole.Replica` as the Enterspeed jobs is only configured to run on servers configured as `ServerRole.Master` and `ServerRole.Single`. Also upgraded the logging about this from debug to information.
+
 ## [3.3.0 - 2023-01-25]
 ### Added
   - Added property validation to make sure null is not passed as a value
-  - 
+
 ## [3.2.0 - 2022-12-13]
 ### Added
   - Added virtual method to extend property data (Umbraco 8, 9, 10)

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/Tasks/HandleEnterspeedJobsTask.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/Tasks/HandleEnterspeedJobsTask.cs
@@ -46,7 +46,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components.Tasks
             }
             else
             {
-                _logger.Debug<HandleEnterspeedJobsTask>("Does not run on servers with {role} role.", _runtime.ToString());
+                _logger.Info<HandleEnterspeedJobsTask>("Does not run on servers with {role} role.", _runtime.ToString());
             }
 
             return true;

--- a/src/Enterspeed.Source.UmbracoCms.V8/Components/Tasks/InvalidateEnterspeedJobsTask.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Components/Tasks/InvalidateEnterspeedJobsTask.cs
@@ -45,7 +45,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Components.Tasks
             }
             else
             {
-                _logger.Debug<InvalidateEnterspeedJobsTask>("Does not run on servers with {role} role.", _runtime.ToString());
+                _logger.Info<InvalidateEnterspeedJobsTask>("Does not run on servers with {role} role.", _runtime.ToString());
             }
 
             return true;

--- a/src/Enterspeed.Source.UmbracoCms.V8/Controllers/Api/DashboardApiController.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Controllers/Api/DashboardApiController.cs
@@ -18,6 +18,7 @@ using Enterspeed.Source.UmbracoCms.V8.Models.Api;
 using Enterspeed.Source.UmbracoCms.V8.Models.Configuration;
 using Enterspeed.Source.UmbracoCms.V8.Providers;
 using Enterspeed.Source.UmbracoCms.V8.Services;
+using Umbraco.Core;
 using Umbraco.Web.WebApi;
 
 namespace Enterspeed.Source.UmbracoCms.V8.Controllers.Api
@@ -29,17 +30,20 @@ namespace Enterspeed.Source.UmbracoCms.V8.Controllers.Api
         private readonly IEnterspeedJobService _enterspeedJobService;
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
         private readonly IEnterspeedConnection _enterspeedConnection;
+        private readonly IRuntimeState _runtimeState;
 
         public DashboardApiController(
             IEnterspeedJobRepository enterspeedJobRepository,
             IEnterspeedJobService enterspeedJobService,
             IEnterspeedConfigurationService enterspeedConfigurationService,
-            IEnterspeedConnection enterspeedConnection)
+            IEnterspeedConnection enterspeedConnection,
+            IRuntimeState runtimeState)
         {
             _enterspeedJobRepository = enterspeedJobRepository;
             _enterspeedJobService = enterspeedJobService;
             _enterspeedConfigurationService = enterspeedConfigurationService;
             _enterspeedConnection = enterspeedConnection;
+            _runtimeState = runtimeState;
         }
 
         [HttpGet]
@@ -79,12 +83,12 @@ namespace Enterspeed.Source.UmbracoCms.V8.Controllers.Api
         }
 
         [HttpGet]
-        public ApiResponse<EnterspeedUmbracoConfiguration> GetEnterspeedConfiguration()
+        public ApiResponse<EnterspeedUmbracoConfigurationResponse> GetEnterspeedConfiguration()
         {
             var config = _enterspeedConfigurationService.GetConfiguration();
-            return new ApiResponse<EnterspeedUmbracoConfiguration>
+            return new ApiResponse<EnterspeedUmbracoConfigurationResponse>
             {
-                Data = config,
+                Data = new EnterspeedUmbracoConfigurationResponse(config, _runtimeState.ServerRole),
                 IsSuccess = true
             };
         }

--- a/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Enterspeed.Source.UmbracoCms.V8.csproj
@@ -340,6 +340,7 @@
     <Compile Include="Handlers\PreviewDictionaries\EnterspeedPreviewDictionaryItemDeleteJobHandler.cs" />
     <Compile Include="Handlers\PreviewDictionaries\EnterspeedPreviewDictionaryItemPublishJobHandler.cs" />
     <Compile Include="Models\Api\ApiResponse.cs" />
+    <Compile Include="Models\Api\EnterspeedUmbracoConfigurationResponse.cs" />
     <Compile Include="Models\Api\ErrorResponse.cs" />
     <Compile Include="Models\Api\SeedResponse.cs" />
     <Compile Include="Models\Configuration\EnterspeedUmbracoConfiguration.cs" />

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/Api/EnterspeedUmbracoConfigurationResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/Api/EnterspeedUmbracoConfigurationResponse.cs
@@ -1,0 +1,17 @@
+﻿using Enterspeed.Source.UmbracoCms.V8.Models.Configuration;
+using Umbraco.Core.Sync;
+
+namespace Enterspeed.Source.UmbracoCms.V8.Models.Api
+{
+    public class EnterspeedUmbracoConfigurationResponse : EnterspeedUmbracoConfiguration
+    {
+        public string ServerRole { get; }
+        public EnterspeedUmbracoConfiguration Configuration { get; }
+
+        public EnterspeedUmbracoConfigurationResponse(EnterspeedUmbracoConfiguration enterspeedUmbracoConfiguration, ServerRole serverRole)
+        {
+            Configuration = enterspeedUmbracoConfiguration;
+            ServerRole = serverRole.ToString();
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/configuration.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/configuration.controller.js
@@ -14,10 +14,11 @@
         dashboardResources.getEnterspeedConfiguration()
             .then(function(result) {
                 if (result.data.isSuccess) {
-                    vm.configuration.baseUrl = result.data.data.baseUrl;
-                    vm.configuration.apiKey = result.data.data.apiKey;
-                    vm.configuration.mediaDomain = result.data.data.mediaDomain;
-                    vm.configuration.previewApiKey = result.data.data.previewApiKey;
+                    vm.configuration.baseUrl = result.data.data.configuration.baseUrl;
+                    vm.configuration.apiKey = result.data.data.configuration.apiKey;
+                    vm.configuration.mediaDomain = result.data.data.configuration.mediaDomain;
+                    vm.configuration.previewApiKey = result.data.data.configuration.previewApiKey;
+                    vm.serverRole = result.data.data.serverRole;
                     vm.loadingConfiguration = false;
                     vm.buttonState = null;
                 }

--- a/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/configuration.view.html
+++ b/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/configuration.view.html
@@ -5,6 +5,11 @@
 
 	<div class="configuration-dashboard-content" ng-if="!vm.loadingConfiguration">
 
+        <div ng-if="vm.serverRole === 'Replica'" class="info-box">
+            <strong>Enterspeed jobs will not run on this current server.</strong><br />
+            Enterspeed jobs will only run on servers with Umbraco role of <i>Master</i> or <i>Single</i>. Current Umbraco server role is <i>{{vm.serverRole}}</i>.
+        </div>
+
 		<div class="configuration-dashboard-property">
 			<label for="api-key">Enterspeed endpoint</label><br />
 			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.baseUrl" placeholder="Enterspeed base url" ng-disabled="vm.buttonState === 'busy'" />
@@ -17,10 +22,10 @@
 			<label for="api-key">Api key</label><br />
 			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.apiKey" placeholder="Enterspeed API Key" ng-disabled="vm.buttonState === 'busy'" />
 		</div>
-        <div class="configuration-dashboard-property">
-            <label for="preview-api-key">Preview api key</label><br />
-            <input type="text" id="preview-api-key" class="input-field" ng-model="vm.configuration.previewApiKey" placeholder="Enterspeed preview API Key" ng-disabled="vm.buttonState === 'busy'" />
-        </div>
+		<div class="configuration-dashboard-property">
+			<label for="preview-api-key">Preview api key</label><br />
+			<input type="text" id="preview-api-key" class="input-field" ng-model="vm.configuration.previewApiKey" placeholder="Enterspeed preview API Key" ng-disabled="vm.buttonState === 'busy'" />
+		</div>
 
 		<umb-button action="vm.saveConfiguration()"
 					type="button"

--- a/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/styles.css
+++ b/src/Enterspeed.Source.UmbracoCms.V8/_content/App_Plugins/Enterspeed.Dashboard/styles.css
@@ -43,13 +43,26 @@
 	padding: 10px 5px;
 }
 
-	.configuration-dashboard-property label {
-		font-weight: 700;
-	}
+.configuration-dashboard-property label {
+	font-weight: 700;
+}
 
-	.configuration-dashboard-property input {
-		width: 750px;
-	}
+.configuration-dashboard-property input {
+	width: 750px;
+}
+
+.info-box {
+    border-radius: 3px;
+    background-color: #2152a3;
+    display: table;
+    font-size: 15px;
+    line-height: 20px;
+    margin-bottom: 0;
+    padding: 6px 14px;
+    vertical-align: middle;
+    color: white;
+    margin-bottom: 10px;
+}
 
 .seed-dashboard-text {
 	padding: 0 0 20px 5px;

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/configuration.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/configuration.controller.js
@@ -14,10 +14,11 @@
         dashboardResources.getEnterspeedConfiguration()
             .then(function(result) {
                 if (result.data.isSuccess) {
-                    vm.configuration.baseUrl = result.data.data.baseUrl;
-                    vm.configuration.apiKey = result.data.data.apiKey;
-                    vm.configuration.mediaDomain = result.data.data.mediaDomain;
-                    vm.configuration.previewApiKey = result.data.data.previewApiKey;
+                    vm.configuration.baseUrl = result.data.data.configuration.baseUrl;
+                    vm.configuration.apiKey = result.data.data.configuration.apiKey;
+                    vm.configuration.mediaDomain = result.data.data.configuration.mediaDomain;
+                    vm.configuration.previewApiKey = result.data.data.configuration.previewApiKey;
+                    vm.serverRole = result.data.data.serverRole;
                     vm.loadingConfiguration = false;
                     vm.buttonState = null;
                 }

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/configuration.view.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/configuration.view.html
@@ -4,8 +4,13 @@
 	</umb-load-indicator>
 
 	<div class="configuration-dashboard-content" ng-if="!vm.loadingConfiguration">
+		
+        <div ng-if="vm.serverRole === 'Subscriber'" class="info-box">
+            <strong>Enterspeed jobs will not run on this current server.</strong><br/>
+            Enterspeed jobs will only run on servers with Umbraco role of <i>SchedulingPublisher</i> or <i>Single</i>. Current Umbraco server role is <i>{{vm.serverRole}}</i>.
+        </div>
 
-		<div class="configuration-dashboard-property">
+        <div class="configuration-dashboard-property">
 			<label for="api-key">Enterspeed endpoint</label><br />
 			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.baseUrl" placeholder="Enterspeed base url" ng-disabled="vm.buttonState === 'busy'" />
 		</div>

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/styles.css
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/styles.css
@@ -43,13 +43,26 @@
 	padding: 10px 5px;
 }
 
-	.configuration-dashboard-property label {
-		font-weight: 700;
-	}
+.configuration-dashboard-property label {
+	font-weight: 700;
+}
 
-	.configuration-dashboard-property input {
-		width: 750px;
-	}
+.configuration-dashboard-property input {
+	width: 750px;
+}
+
+.info-box {
+    border-radius: 3px;
+    background-color: #2152a3;
+    display: table;
+    font-size: 15px;
+    line-height: 20px;
+    margin-bottom: 0;
+    padding: 6px 14px;
+    vertical-align: middle;
+    color: white;
+    margin-bottom: 10px;
+}
 
 .seed-dashboard-text {
 	padding: 0 0 20px 5px;

--- a/src/Enterspeed.Source.UmbracoCms/Controllers/Api/DashboardApiController.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Controllers/Api/DashboardApiController.cs
@@ -19,6 +19,7 @@ using Enterspeed.Source.UmbracoCms.Models.Configuration;
 using Enterspeed.Source.UmbracoCms.Models.Api;
 using Enterspeed.Source.UmbracoCms.Services;
 using Enterspeed.Source.UmbracoCms.Extensions;
+using Umbraco.Cms.Core.Sync;
 #if NET5_0
 using Umbraco.Cms.Core.Scoping;
 #else
@@ -31,6 +32,7 @@ namespace Enterspeed.Source.UmbracoCms.Controllers.Api
     public class DashboardApiController : UmbracoAuthorizedApiController
     {
         private readonly IScopeProvider _scopeProvider;
+        private readonly IServerRoleAccessor _serverRoleAccessor;
         private readonly IEnterspeedJobRepository _enterspeedJobRepository;
         private readonly IEnterspeedJobService _enterspeedJobService;
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
@@ -43,7 +45,8 @@ namespace Enterspeed.Source.UmbracoCms.Controllers.Api
             IEnterspeedConfigurationService enterspeedConfigurationService,
             IEnterspeedConnection enterspeedConnection,
             IHttpContextAccessor httpContextAccessor,
-            IScopeProvider scopeProvider)
+            IScopeProvider scopeProvider,
+            IServerRoleAccessor serverRoleAccessor)
         {
             _enterspeedJobRepository = enterspeedJobRepository;
             _enterspeedJobService = enterspeedJobService;
@@ -51,6 +54,7 @@ namespace Enterspeed.Source.UmbracoCms.Controllers.Api
             _enterspeedConnection = enterspeedConnection;
             _httpContextAccessor = httpContextAccessor;
             _scopeProvider = scopeProvider;
+            _serverRoleAccessor = serverRoleAccessor;
         }
 
         [HttpGet]
@@ -97,12 +101,12 @@ namespace Enterspeed.Source.UmbracoCms.Controllers.Api
         }
 
         [HttpGet]
-        public ApiResponse<EnterspeedUmbracoConfiguration> GetEnterspeedConfiguration()
+        public ApiResponse<EnterspeedUmbracoConfigurationResponse> GetEnterspeedConfiguration()
         {
             var config = _enterspeedConfigurationService.GetConfiguration();
-            return new ApiResponse<EnterspeedUmbracoConfiguration>
+            return new ApiResponse<EnterspeedUmbracoConfigurationResponse>
             {
-                Data = config,
+                Data = new EnterspeedUmbracoConfigurationResponse(config, _serverRoleAccessor.CurrentServerRole),
                 IsSuccess = true
             };
         }

--- a/src/Enterspeed.Source.UmbracoCms/HostedServices/HandleEnterspeedJobsHostedService.cs
+++ b/src/Enterspeed.Source.UmbracoCms/HostedServices/HandleEnterspeedJobsHostedService.cs
@@ -58,7 +58,7 @@ namespace Enterspeed.Source.UmbracoCms.HostedServices
                 }
                 else
                 {
-                    logger.LogDebug("Does not run on servers with {role} role.", serverRoleAccessor.CurrentServerRole.ToString());
+                    logger.LogInformation("Does not run on servers with {role} role.", serverRoleAccessor.CurrentServerRole.ToString());
                 }
 
                 return Task.CompletedTask;

--- a/src/Enterspeed.Source.UmbracoCms/HostedServices/InvalidateEnterspeedJobsHostedService.cs
+++ b/src/Enterspeed.Source.UmbracoCms/HostedServices/InvalidateEnterspeedJobsHostedService.cs
@@ -57,7 +57,7 @@ namespace Enterspeed.Source.UmbracoCms.HostedServices
                 }
                 else
                 {
-                    logger.LogDebug("Does not run on servers with {role} role.", serverRoleAccessor.CurrentServerRole.ToString());
+                    logger.LogInformation("Does not run on servers with {role} role.", serverRoleAccessor.CurrentServerRole.ToString());
                 }
 
                 return Task.CompletedTask;

--- a/src/Enterspeed.Source.UmbracoCms/Models/Api/EnterspeedUmbracoConfigurationResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/Api/EnterspeedUmbracoConfigurationResponse.cs
@@ -1,0 +1,17 @@
+﻿using Enterspeed.Source.UmbracoCms.Models.Configuration;
+using Umbraco.Cms.Core.Sync;
+
+namespace Enterspeed.Source.UmbracoCms.Models.Api
+{
+    public class EnterspeedUmbracoConfigurationResponse : EnterspeedUmbracoConfiguration
+    {
+        public ServerRole ServerRole { get; }
+        public EnterspeedUmbracoConfiguration Configuration { get; }
+
+        public EnterspeedUmbracoConfigurationResponse(EnterspeedUmbracoConfiguration enterspeedUmbracoConfiguration, ServerRole serverRole)
+        {
+            Configuration = enterspeedUmbracoConfiguration;
+            ServerRole = serverRole;
+        }
+    }
+}


### PR DESCRIPTION
The Enterspeed jobs is only triggered if Umbraco runs with specific server roles. The PR will add a small info box to the Enterspeed configuration page if the server has a different role.

Added to Umbraco 8 and up.

Remember to copy the App_Plugins folder if you wan't to test it.

![image](https://user-images.githubusercontent.com/2575817/217264800-df1eac87-67e5-471c-870e-f1990f4ba354.png)
