### PR TITLE
Updated EnterspeedUmbracoConfiguration

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -6,6 +6,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 
 ## [Unreleased]
+### Breaking changes
+- Fixed configuration stored in database even if you are using settings file. If you are using the settings file, the settings file  will now take priority over potential configuration in the database.
+  Also the UI will show a message indicating if the settings are loaded from the settings file and you cant save configuration changes from the UI.
+
 ### Added
 - Added information note on the Enterspeed settings page, if the Umbraco server is running with `ServerRole.Subscriber` as the Enterspeed jobs is only configured to run on servers configured as `ServerRole.SchedulingPublisher` and `ServerRole.Single`. Also upgraded the logging about this from debug to information.
 - Ingesting medias to Enterspeed for preview

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/configuration.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/configuration.controller.js
@@ -18,6 +18,7 @@
                     vm.configuration.apiKey = result.data.data.configuration.apiKey;
                     vm.configuration.mediaDomain = result.data.data.configuration.mediaDomain;
                     vm.configuration.previewApiKey = result.data.data.configuration.previewApiKey;
+                    vm.configuration.configuredFromSettingsFile = result.data.data.configuration.configuredFromSettingsFile;
                     vm.serverRole = result.data.data.serverRole;
                     vm.loadingConfiguration = false;
                     vm.buttonState = null;

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/configuration.view.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/configuration.view.html
@@ -10,21 +10,26 @@
             Enterspeed jobs will only run on servers with Umbraco role of <i>SchedulingPublisher</i> or <i>Single</i>. Current Umbraco server role is <i>{{vm.serverRole}}</i>.
         </div>
 
+		<div ng-if="vm.configuration.configuredFromSettingsFile" class="info-box">
+			<strong>The configuration is loaded from the <i>appsettings.json</i> file.</strong><br />
+			Go to the <i>appsettings.json</i> file to change the values.
+		</div>
+
         <div class="configuration-dashboard-property">
 			<label for="api-key">Enterspeed endpoint</label><br />
-			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.baseUrl" placeholder="Enterspeed base url" ng-disabled="vm.buttonState === 'busy'" />
+			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.baseUrl" placeholder="Enterspeed base url" ng-disabled="vm.buttonState === 'busy' || vm.configuration.configuredFromSettingsFile" />
 		</div>
 		<div class="configuration-dashboard-property">
             <label for="media-domain">Media domain</label><br />
-            <input type="text" id="media-domain" class="input-field" ng-model="vm.configuration.mediaDomain" placeholder="Media domain" ng-disabled="vm.buttonState === 'busy'" />
+            <input type="text" id="media-domain" class="input-field" ng-model="vm.configuration.mediaDomain" placeholder="Media domain" ng-disabled="vm.buttonState === 'busy' || vm.configuration.configuredFromSettingsFile" />
         </div>
 		<div class="configuration-dashboard-property">
 			<label for="api-key">Api key</label><br />
-			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.apiKey" placeholder="Enterspeed API Key" ng-disabled="vm.buttonState === 'busy'" />
+			<input type="text" id="api-key" class="input-field" ng-model="vm.configuration.apiKey" placeholder="Enterspeed API Key" ng-disabled="vm.buttonState === 'busy' || vm.configuration.configuredFromSettingsFile" />
 		</div>
 		<div class="configuration-dashboard-property">
             <label for="preview-api-key">Preview api key</label><br />
-            <input type="text" id="preview-api-key" class="input-field" ng-model="vm.configuration.previewApiKey" placeholder="Enterspeed preview API Key" ng-disabled="vm.buttonState === 'busy'" />
+            <input type="text" id="preview-api-key" class="input-field" ng-model="vm.configuration.previewApiKey" placeholder="Enterspeed preview API Key" ng-disabled="vm.buttonState === 'busy' || vm.configuration.configuredFromSettingsFile" />
         </div>
 
 		<umb-button action="vm.saveConfiguration()"
@@ -32,7 +37,7 @@
 					button-style="success"
 					state="vm.configState"
 					label="Save configuration"
-					disabled="vm.buttonState === 'busy' || !vm.configuration.baseUrl || !vm.configuration.apiKey">
+					disabled="vm.buttonState === 'busy' || !vm.configuration.baseUrl || !vm.configuration.apiKey || vm.configuration.configuredFromSettingsFile">
 		</umb-button>
 
 		<umb-button action="vm.testConnection()"

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/styles.css
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/styles.css
@@ -52,9 +52,9 @@
 }
 
 .info-box {
+    width: 750px;
     border-radius: 3px;
     background-color: #2152a3;
-    display: table;
     font-size: 15px;
     line-height: 20px;
     margin-bottom: 0;

--- a/src/Enterspeed.Source.UmbracoCms/Models/Configuration/EnterspeedUmbracoConfiguration.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/Configuration/EnterspeedUmbracoConfiguration.cs
@@ -6,6 +6,7 @@ namespace Enterspeed.Source.UmbracoCms.Models.Configuration
     {
         public string MediaDomain { get; set; }
         public bool IsConfigured { get; set; }
+        public bool ConfiguredFromSettingsFile { get; set; }
         public string PreviewApiKey { get; set; }
     }
 }


### PR DESCRIPTION
This PR changes the priority of reading configuration. If the settings file is used this configuration will take priority over potential configuration in the database.

Also if settings files is used the save button and input fields will be disabled and the UI give a message saying that the configuration is loaded from the settings file.

Added to Umbraco 9 and up.

Remember to copy the App_Plugins folder if you wan't to test it.

Note: this is a breaking change.

![image](https://user-images.githubusercontent.com/2575817/217842975-3ee093e6-8bba-4b1b-88bf-b138fa182d94.png)
