### PR TITLE
Made CanHandle and Handle virtual

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unrelease]
+### Changed
+- Made `CanHandle` and `Handle` on all types of `IEnterspeedJobHandler` virtual to allow overriding these methods if you want to customize the logic for specific handlers.
+
 ## [2.0.0 - 2023-02-15]
 ### Breaking changes
 - Fixed configuration stored in database even if you are using settings file. If you are using the settings file, the settings file  will now take priority over potential configuration in the database.

--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.netframework.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.netframework.md
@@ -4,6 +4,9 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [unrelease]
+### Changed
+- Made `CanHandle` and `Handle` on all types of `IEnterspeedJobHandler` virtual to allow overriding these methods if you want to customize the logic for specific handlers. (Umbraco 8)
 
 ## [3.4.0 - 2023-02-15]
 ### Added

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Content/EnterspeedContentDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Content/EnterspeedContentDeleteJobHandler.cs
@@ -24,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
                 && job.JobType == EnterspeedJobType.Delete;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Dictionaries/EnterspeedDictionaryItemDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Dictionaries/EnterspeedDictionaryItemDeleteJobHandler.cs
@@ -24,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
                && job.ContentState == EnterspeedContentState.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Dictionaries/EnterspeedDictionaryItemPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Dictionaries/EnterspeedDictionaryItemPublishJobHandler.cs
@@ -38,7 +38,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -47,7 +47,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var dictionaryItem = GetDictionaryItem(job);
             if (!CanIngest(dictionaryItem, job))

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -41,7 +41,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
             _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -50,7 +50,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var media = GetMedia(job);
             if (!CanIngest(media, job))

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaTrashedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/Media/EnterspeedMediaTrashedJobHandler.cs
@@ -24,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
             _logger = logger;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.Media
                && job.ContentState == EnterspeedContentState.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var parsed = int.TryParse(job.EntityId, out var parsedId);
 

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewContent/EnterspeedPreviewContentDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewContent/EnterspeedPreviewContentDeleteJobHandler.cs
@@ -1,9 +1,4 @@
-﻿using System;
-using System.Collections.Generic;
-using System.Linq;
-using System.Net;
-using System.Text;
-using System.Threading.Tasks;
+﻿using System.Net;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.V8.Data.Models;
 using Enterspeed.Source.UmbracoCms.V8.Exceptions;
@@ -29,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -38,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
                 && job.JobType == EnterspeedJobType.Delete;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview));

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
@@ -50,7 +50,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
             _publishedRouter = publishedRouter;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
                    && job.EntityType == EnterspeedJobEntityType.Content

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemDeleteJobHandler.cs
@@ -24,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewDictionaries
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewDictionaries
                 && job.ContentState == EnterspeedContentState.Preview;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview));

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemPublishJobHandler.cs
@@ -38,7 +38,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewDictionaries
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -47,7 +47,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewDictionaries
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var dictionaryItem = GetDictionaryItem(job);
             if (!CanIngest(dictionaryItem, job))

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewMedia/EnterspeedPreviewMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewMedia/EnterspeedPreviewMediaPublishJobHandler.cs
@@ -41,7 +41,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewMedia
             _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -50,7 +50,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewMedia
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var media = GetMedia(job);
             if (!CanIngest(media, job))

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewMedia/EnterspeedPreviewMediaTrashedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewMedia/EnterspeedPreviewMediaTrashedJobHandler.cs
@@ -24,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewMedia
             _logger = logger;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewMedia
                && job.ContentState == EnterspeedContentState.Preview;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var parsed = int.TryParse(job.EntityId, out var parsedId);
 

--- a/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Models/UmbracoMediaEntity.cs
@@ -16,12 +16,13 @@ namespace Enterspeed.Source.UmbracoCms.V8.Models
             IMedia media,
             IEnterspeedPropertyService propertyService,
             IEntityIdentityService entityIdentityService,
-            IEnterspeedConfigurationService enterspeedConfigurationService)
+            IEnterspeedConfigurationService enterspeedConfigurationService,
+            string customUrl = null)
         {
             _media = media;
             _entityIdentityService = entityIdentityService;
-
-            Url = _media.GetMediaUrl(enterspeedConfigurationService.GetConfiguration());
+            
+            Url = !string.IsNullOrWhiteSpace(customUrl) ? customUrl : _media.GetMediaUrl(enterspeedConfigurationService.GetConfiguration());
             Properties = propertyService.GetProperties(_media);
         }
 

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Content/EnterspeedContentDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Content/EnterspeedContentDeleteJobHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.Data.Models;
-using Enterspeed.Source.UmbracoCms.Handlers;
 using Enterspeed.Source.UmbracoCms.Models;
 using Enterspeed.Source.UmbracoCms.Exceptions;
 using Enterspeed.Source.UmbracoCms.Providers;
@@ -25,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Content
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -34,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Content
                 && job.JobType == EnterspeedJobType.Delete;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Dictionaries/EnterspeedDictionaryItemDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Dictionaries/EnterspeedDictionaryItemDeleteJobHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.Data.Models;
-using Enterspeed.Source.UmbracoCms.Handlers;
 using Enterspeed.Source.UmbracoCms.Models;
 using Enterspeed.Source.UmbracoCms.Exceptions;
 using Enterspeed.Source.UmbracoCms.Providers;
@@ -25,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Dictionaries
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -34,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Dictionaries
                 && job.ContentState == EnterspeedContentState.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish));

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Dictionaries/EnterspeedDictionaryItemPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Dictionaries/EnterspeedDictionaryItemPublishJobHandler.cs
@@ -38,7 +38,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Dictionaries
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -47,7 +47,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Dictionaries
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var dictionaryItem = GetDictionaryItem(job);
             if (!CanIngest(dictionaryItem, job))

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Media/EnterspeedMediaPublishJobHandler.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.Data.Models;
-using Enterspeed.Source.UmbracoCms.Handlers;
 using Enterspeed.Source.UmbracoCms.Models;
 using Enterspeed.Source.UmbracoCms.Exceptions;
 using Enterspeed.Source.UmbracoCms.Models.Api;
@@ -43,7 +42,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Media
             _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -52,7 +51,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Media
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var media = GetMedia(job);
             if (!CanIngest(media, job))

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Media/EnterspeedMediaTrashedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Media/EnterspeedMediaTrashedJobHandler.cs
@@ -25,7 +25,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Media
             _logger = logger;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
@@ -34,7 +34,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Media
                && job.ContentState == EnterspeedContentState.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var parsed = int.TryParse(job.EntityId, out var parsedId);
 

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewContent/EnterspeedPreviewContentDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewContent/EnterspeedPreviewContentDeleteJobHandler.cs
@@ -24,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -33,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
                 && job.JobType == EnterspeedJobType.Delete;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview));

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
@@ -4,7 +4,6 @@ using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.Data.Models;
 using Enterspeed.Source.UmbracoCms.Factories;
-using Enterspeed.Source.UmbracoCms.Handlers;
 using Enterspeed.Source.UmbracoCms.Models;
 using Enterspeed.Source.UmbracoCms.Exceptions;
 using Enterspeed.Source.UmbracoCms.Models.Api;
@@ -47,7 +46,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
                    && job.EntityType == EnterspeedJobEntityType.Content

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemDeleteJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemDeleteJobHandler.cs
@@ -1,7 +1,6 @@
 ﻿using System.Net;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.Data.Models;
-using Enterspeed.Source.UmbracoCms.Handlers;
 using Enterspeed.Source.UmbracoCms.Models;
 using Enterspeed.Source.UmbracoCms.Exceptions;
 using Enterspeed.Source.UmbracoCms.Providers;
@@ -25,7 +24,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewDictionaries
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -34,7 +33,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewDictionaries
                 && job.ContentState == EnterspeedContentState.Preview;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var id = _entityIdentityService.GetId(job.EntityId, job.Culture);
             var deleteResponse = _enterspeedIngestService.Delete(id, _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview));

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewDictionaries/EnterspeedPreviewDictionaryItemPublishJobHandler.cs
@@ -3,7 +3,6 @@ using System.Text.Json;
 using Enterspeed.Source.Sdk.Api.Models;
 using Enterspeed.Source.Sdk.Api.Services;
 using Enterspeed.Source.UmbracoCms.Data.Models;
-using Enterspeed.Source.UmbracoCms.Handlers;
 using Enterspeed.Source.UmbracoCms.Models;
 using Enterspeed.Source.UmbracoCms.Exceptions;
 using Enterspeed.Source.UmbracoCms.Models.Api;
@@ -39,7 +38,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewDictionaries
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -48,7 +47,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewDictionaries
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var dictionaryItem = GetDictionaryItem(job);
             if (!CanIngest(dictionaryItem, job))

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewMedia/EnterspeedPreviewMediaPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewMedia/EnterspeedPreviewMediaPublishJobHandler.cs
@@ -41,7 +41,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewMedia
             _enterspeedConfigurationService = enterspeedConfigurationService;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -50,7 +50,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewMedia
                 && job.JobType == EnterspeedJobType.Publish;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var media = GetMedia(job);
             if (!CanIngest(media, job))

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewMedia/EnterspeedPreviewMediaTrashedJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewMedia/EnterspeedPreviewMediaTrashedJobHandler.cs
@@ -25,7 +25,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewMedia
             _logger = logger;
         }
 
-        public bool CanHandle(EnterspeedJob job)
+        public virtual bool CanHandle(EnterspeedJob job)
         {
             return
                 _enterspeedConnectionProvider.GetConnection(ConnectionType.Preview) != null
@@ -34,7 +34,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewMedia
                 && job.ContentState == EnterspeedContentState.Preview;
         }
 
-        public void Handle(EnterspeedJob job)
+        public virtual void Handle(EnterspeedJob job)
         {
             var parsed = int.TryParse(job.EntityId, out var parsedId);
 

--- a/src/Enterspeed.Source.UmbracoCms/Models/UmbracoMediaEntity.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/UmbracoMediaEntity.cs
@@ -16,12 +16,13 @@ namespace Enterspeed.Source.UmbracoCms.Models
             IMedia media,
             IEnterspeedPropertyService propertyService,
             IEntityIdentityService entityIdentityService,
-            IEnterspeedConfigurationService enterspeedConfigurationService)
+            IEnterspeedConfigurationService enterspeedConfigurationService,
+            string customUrl = null)
         {
             _media = media;
             _entityIdentityService = entityIdentityService;
-
-            Url = _media.GetMediaUrl(enterspeedConfigurationService.GetConfiguration());
+            
+            Url = !string.IsNullOrWhiteSpace(customUrl) ? customUrl : _media.GetMediaUrl(enterspeedConfigurationService.GetConfiguration());
             Properties = propertyService.GetProperties(_media);
         }
 


### PR DESCRIPTION
Made `CanHandle` and `Handle` on all types of `IEnterspeedJobHandler` virtual to allow overriding these methods if you want to customize the logic for specific handlers.

Feature request from Wølund og Wraae and a requirement for the Cloudinary add-on package (https://app.shortcut.com/enterspeed/story/2530/create-add-on-package-to-umbraco-source-for-cloudinary)

Made for Umbraco 8+