### PR TITLE
fix: allow sortOrder changes on saved variant to be updated in published storage

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms/NotificationHandlers/EnterspeedContentCacheRefresherNotificationHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/NotificationHandlers/EnterspeedContentCacheRefresherNotificationHandler.cs
@@ -84,9 +84,14 @@ namespace Enterspeed.Source.UmbracoCms.NotificationHandlers
                             continue;
                         }
 
-                        if (audit.AuditType.Equals(AuditType.PublishVariant)
+                        if (audit.AuditType.Equals(AuditType.PublishVariant) 
                                 || audit.AuditType.Equals(AuditType.Publish)
-                                || audit.AuditType.Equals(AuditType.Move))
+                                || audit.AuditType.Equals(AuditType.Move)
+                                // SaveVariant and Save are added to support sortOrder updates
+                                || audit.AuditType.Equals(AuditType.SaveVariant) 
+                                || audit.AuditType.Equals(AuditType.Save) 
+                                // SortOrder changes does not currently have AuditType.Sort but added here to support potential future changes.
+                                || audit.AuditType.Equals(AuditType.Sort))
                         {
                             var cultures = node.ContentType.VariesByCulture()
                                 ? node.Cultures.Keys


### PR DESCRIPTION
When updating the sort order of child nodes, the sort order is only updated in preview storage but not in published storage if the node has unpublished changes.

AuditType.Sort is not currently used, so that does not solve the issue. A node with unpublished changes will have AuditType.SaveVariants or AuditType.Save. 

Added all AuditTypes to the allowed types in the guard before ingesting into published storage.

This is safe because it's always the published node that gets ingested (not the unpublished node data). However, this will result in more jobs. The date changes guard later in the logic doesn't affect the cases I tested. However, the ingest endpoint on the Enterspeed side nows if there are any changes to the entity. If sortOrder is changed it is ingested. If the node is only saved, Enterspeed returns {"status":200,"message":"Source entity hasn't changed and won't be processed."}