### PR TITLE
Added option to clear seeded queue items

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Resources/dashboard.resources.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Resources/dashboard.resources.js
@@ -8,6 +8,12 @@
                 seed: function () {
                     return $http.get("/umbraco/backoffice/api/DashboardApi/Seed");
                 },
+                clearPendingJobs: function () {
+                    return $http.post("/umbraco/backoffice/api/DashboardApi/ClearPendingJobs");
+                },
+                getNumberOfPendingJobs: function () {
+                    return $http.get("/umbraco/backoffice/api/DashboardApi/GetNumberOfPendingJobs");
+                },
                 getEnterspeedConfiguration: function () {
                     return $http.get("/umbraco/backoffice/api/DashboardApi/GetEnterspeedConfiguration");
                 },

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/seed.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/seed.controller.js
@@ -1,23 +1,54 @@
 ﻿function seedController(dashboardResources, notificationsService) {
     var vm = this;
     vm.seedState = "success";
+    vm.clearPendingJobsState = "success";
+    vm.numberOfPendingJobs = 0;
     vm.seedResponse = null;
 
     function init() {
+        getNumberOfPendingJobs();
+
+        setInterval(getNumberOfPendingJobs, 10 * 1000);
     }
 
     vm.seed = function () {
         vm.seedState = "busy";
         dashboardResources.seed().then(function (result) {
             if (result.data.isSuccess) {
-                notificationsService.success("Seed", "Successfully started seeding Enterspeed")
+                notificationsService.success("Seed", "Successfully started seeding to Enterspeed");
                 vm.seedResponse = result.data.data;
+                vm.numberOfPendingJobs = result.data.data.numberOfPendingJobs;
             } else {
                 vm.seedResponse = null;
             }
             vm.seedState = "success";
         }, function (error) {
             notificationsService.error("Seed", error.data.message);
+        });
+    };
+
+    vm.clearPendingJobs = function () {
+        vm.clearPendingJobsState = "busy";
+        dashboardResources.clearPendingJobs().then(function (result) {
+            if (result.data.isSuccess) {
+                notificationsService.success("Clear job queue", "Successfully cleared the queue of pending jobs");
+                vm.numberOfPendingJobs = 0;
+            }
+            vm.clearPendingJobsState = "success";
+        }, function (error) {
+            notificationsService.error("Clear job queue", error.data.message);
+        });
+    };
+
+    function getNumberOfPendingJobs () {
+        dashboardResources.getNumberOfPendingJobs().then(function (result) {
+            if (result.data.isSuccess) {
+                vm.numberOfPendingJobs = result.data.data.numberOfPendingJobs;
+            } else {
+                vm.numberOfPendingJobs = 0;
+            }
+        }, function (error) {
+            notificationsService.error("Failed to check queue length", error.data.message);
         });
     };
 

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
@@ -15,7 +15,8 @@
         </div>
     </div>
     <div class="seed-dashboard-text">
-        Seeding will queue jobs for all content, media and dictionary item for publish and preview (if configured) within this Umbraco installation. This action can take a while to finish.
+        <p>Seeding will queue jobs for all content, media and dictionary item for publish and preview (if configured) within this Umbraco installation. This action can take a while to finish.</p>
+        <i>The job queue length is the queue length on Umbraco before the nodes are ingested into Enterspeed.</i>
     </div>
     <div class="seed-dashboard-content">
         <umb-button action="vm.seed()"

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
@@ -25,5 +25,12 @@
                     label="Seed"
                     disabled="vm.seedState === 'busy'">
         </umb-button>
+        <umb-button action="vm.clearPendingJobs()"
+                    type="button"
+                    button-style="action"
+                    state="vm.clearPendingJobsState"
+                    label="Clear job queue ({{vm.numberOfPendingJobs}})"
+                    disabled="vm.clearPendingJobsState === 'busy' || vm.numberOfPendingJobs === 0">
+        </umb-button>
     </div>
 </div>

--- a/src/Enterspeed.Source.UmbracoCms/Controllers/Api/DashboardApiController.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Controllers/Api/DashboardApiController.cs
@@ -168,7 +168,22 @@ namespace Enterspeed.Source.UmbracoCms.Controllers.Api
         {
             using (var scope = _scopeProvider.CreateScope(autoComplete: true))
             {
-                var numberOfPendingJobs = _enterspeedJobRepository.GetNumberOfPendingJobs();
+                int numberOfPendingJobs;
+                try
+                {
+                    numberOfPendingJobs = _enterspeedJobRepository.GetNumberOfPendingJobs();
+                }
+                catch (Exception exception)
+                {
+                    return BadRequest(
+                        new Response
+                        {
+                            Status = HttpStatusCode.BadRequest,
+                            Success = false,
+                            Message = exception.Message,
+                            Exception = exception
+                        });
+                }
 
                 return Ok(
                     new ApiResponse<GetNumberOfPendingJobsResponse>

--- a/src/Enterspeed.Source.UmbracoCms/Controllers/Api/DashboardApiController.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Controllers/Api/DashboardApiController.cs
@@ -163,6 +163,37 @@ namespace Enterspeed.Source.UmbracoCms.Controllers.Api
                 });
         }
 
+        [HttpGet]
+        public IActionResult GetNumberOfPendingJobs()
+        {
+            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
+            {
+                var numberOfPendingJobs = _enterspeedJobRepository.GetNumberOfPendingJobs();
+
+                return Ok(
+                    new ApiResponse<GetNumberOfPendingJobsResponse>
+                    {
+                        Data = new GetNumberOfPendingJobsResponse { NumberOfPendingJobs = numberOfPendingJobs },
+                        IsSuccess = true
+                    });
+            }
+        }
+
+        [HttpPost]
+        public IActionResult ClearPendingJobs()
+        {
+            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
+            {
+                _enterspeedJobRepository.ClearPendingJobs();
+
+                return Ok(
+                    new ApiResponse
+                    {
+                        IsSuccess = true
+                    });
+            }
+        }
+
         [HttpPost]
         public IActionResult TestConfigurationConnection(EnterspeedUmbracoConfiguration configuration)
         {

--- a/src/Enterspeed.Source.UmbracoCms/Data/Repositories/EnterspeedJobRepository.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Data/Repositories/EnterspeedJobRepository.cs
@@ -70,6 +70,15 @@ namespace Enterspeed.Source.UmbracoCms.Data.Repositories
             return result;
         }
 
+        public int GetNumberOfPendingJobs()
+        {
+            var numberOfPendingJobs = Database.Query<EnterspeedJobSchema>()
+                .Where(x => x.JobState == EnterspeedJobState.Pending.GetHashCode())
+                .Count();
+            
+            return numberOfPendingJobs;
+        }
+
         public IList<EnterspeedJob> GetOldProcessingTasks(int olderThanMinutes = 60)
         {
             var result = new List<EnterspeedJob>();
@@ -100,6 +109,13 @@ namespace Enterspeed.Source.UmbracoCms.Data.Repositories
         {
             Database.DeleteMany<EnterspeedJobSchema>()
                 .Where(x => ids.Contains(x.Id))
+                .Execute();
+        }
+
+        public void ClearPendingJobs()
+        {
+            Database.DeleteMany<EnterspeedJobSchema>()
+                .Where(x => x.JobState == EnterspeedJobState.Pending.GetHashCode())
                 .Execute();
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms/Data/Repositories/IEnterspeedJobRepository.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Data/Repositories/IEnterspeedJobRepository.cs
@@ -11,5 +11,7 @@ namespace Enterspeed.Source.UmbracoCms.Data.Repositories
         IList<EnterspeedJob> GetOldProcessingTasks(int olderThanMinutes = 60);
         void Save(IList<EnterspeedJob> jobs);
         void Delete(IList<int> ids);
+        void ClearPendingJobs();
+        int GetNumberOfPendingJobs();
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms/Models/Api/ApiResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/Api/ApiResponse.cs
@@ -1,9 +1,13 @@
 ﻿namespace Enterspeed.Source.UmbracoCms.Models.Api
 {
-    public class ApiResponse<T>
+    public class ApiResponse
     {
         public bool IsSuccess { get; set; }
         public string ErrorCode { get; set; }
+    }
+
+    public class ApiResponse<T> : ApiResponse
+    {
         public T Data { get; set; }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms/Models/Api/GetNumberOfPendingJobsResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/Api/GetNumberOfPendingJobsResponse.cs
@@ -1,0 +1,7 @@
+﻿namespace Enterspeed.Source.UmbracoCms.Models.Api
+{
+    public class GetNumberOfPendingJobsResponse
+    {
+        public int NumberOfPendingJobs { get; set; }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms/Models/Api/SeedResponse.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/Api/SeedResponse.cs
@@ -3,6 +3,7 @@
     public class SeedResponse
     {
         public int JobsAdded { get; set; }
+        public int NumberOfPendingJobs { get; set; }
         public int ContentCount { get; set; }
         public int DictionaryCount { get; set; }
         public long MediaCount { get; set; }

--- a/src/Enterspeed.Source.UmbracoCms/Services/EnterspeedJobService.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Services/EnterspeedJobService.cs
@@ -50,13 +50,15 @@ namespace Enterspeed.Source.UmbracoCms.Services
             var jobs = contentJobs.Union(dictionaryJobs).Union(mediaJobs).ToList();
 
             _enterspeedJobRepository.Save(jobs);
+            var numberOfPendingJobs = _enterspeedJobRepository.GetNumberOfPendingJobs();
 
             return new SeedResponse
             {
                 ContentCount = contentCount,
                 DictionaryCount = dictionaryCount,
                 MediaCount = mediaCount,
-                JobsAdded = jobs.Count
+                JobsAdded = jobs.Count,
+                NumberOfPendingJobs = numberOfPendingJobs
             };
         }
 


### PR DESCRIPTION
Added a new Clear job queue button, to let users clear the job queue in Umbraco if they eg. accidently clicked the seed button. The job handler runs once a minute.

The Clear job queue button is disabled if no job is in queue:

![image](https://user-images.githubusercontent.com/2575817/233625264-7d273cd5-437a-4849-a497-387153cccc57.png)

The clear job queue button shows the number of jobs in queue and automatically check for new number of jobs in queue every 10 second.

![Screenshot 2023-04-21 132953](https://user-images.githubusercontent.com/2575817/233625326-0b095795-a24b-4a57-99e2-4517c2b45df3.png)
