### PR TITLE
Feature/3125 verbose logging

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
@@ -70,7 +70,8 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
                 }
                 catch (Exception exception)
                 {
-                    var message = exception?.Message ?? "Failed to handle the job";
+                    // Exceptions has a ToString() override which formats the full exception nicely.
+                    var message = exception.ToString();
                     failedJobs.Add(_enterspeedJobFactory.GetFailedJob(newestJob, message));
                     _logger.LogWarning(message);
                 }

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
@@ -70,10 +70,10 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
                 }
                 catch (Exception exception)
                 {
+                    failedJobs.Add(_enterspeedJobFactory.GetFailedJob(newestJob, exception.Message));
+                    
                     // Exceptions has a ToString() override which formats the full exception nicely.
-                    var message = exception.ToString();
-                    failedJobs.Add(_enterspeedJobFactory.GetFailedJob(newestJob, message));
-                    _logger.LogWarning(message);
+                    _logger.LogWarning(exception.ToString());
                 }
             }
 


### PR DESCRIPTION
We had an issue where the logged errors were not detailed enough. It made it quite hard to track down the error. 
We will continue to only store the message in our database, but log the full exception. 

In this way we can get some more detailed information about the exception in the Umbraco log