### PR TITLE
Feature/select multiple nodes in one go for custom seeds

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/seed.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/seed.controller.js
@@ -75,7 +75,7 @@
         });
     };
 
-    function getNumberOfPendingJobs () {
+    function getNumberOfPendingJobs() {
         dashboardResources.getNumberOfPendingJobs().then(function (result) {
             if (result.data.isSuccess) {
                 vm.numberOfPendingJobs = result.data.data.numberOfPendingJobs;
@@ -87,42 +87,45 @@
         });
     };
 
-    vm.openSelectNode = function(section) {
+    vm.openSelectNode = function (section) {
         editorService.open({
             title: "Select " + section + " node",
             subtitle: "Select a node to include in the seed",
             view: "/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/selectNode.html",
             contentType: section,
             size: "small",
-            submit: function(value) {
-                if (!value.target || !value.target.id) {
+            submit: function (value) {
+                if (!value.targets) {
                     return;
                 }
 
-                if (value.target.id === "-1") {
-                    vm.selectedNodesToSeed[section] = [value.target];
-                }
-                else {
-                    var existingNodeIndex = vm.selectedNodesToSeed[section].findIndex(element => element.id === value.target.id);
-                    if (existingNodeIndex >= 0) {
-                        vm.selectedNodesToSeed[section][existingNodeIndex] = value.target;
-                    } else {
-                        vm.selectedNodesToSeed[section].push(value.target);
+                for (var i = 0; i < value.targets.length; i++) {
+                    let target = value.targets[i];
+                    if (target.id === "-1") {
+                        vm.selectedNodesToSeed[section] = [target];
+                    }
+                    else {
+                        var existingNodeIndex = vm.selectedNodesToSeed[section].findIndex(element => element.id === target.id);
+                        if (existingNodeIndex >= 0) {
+                            vm.selectedNodesToSeed[section][existingNodeIndex] = target;
+                        } else {
+                            vm.selectedNodesToSeed[section].push(target);
+                        }
                     }
                 }
 
             },
-            close: function() {
+            close: function () {
                 editorService.close();
             }
         });
     }
 
-    vm.removeSelectNode = function(section, index) {
+    vm.removeSelectNode = function (section, index) {
         vm.selectedNodesToSeed[section].splice(index, 1);
     }
 
-    vm.allowAddingNodes = function(section) {
+    vm.allowAddingNodes = function (section) {
         return vm.selectedNodesToSeed[section].findIndex(element => element.id === "-1") < 0;
     }
 

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/selectNode.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/selectNode.controller.js
@@ -9,14 +9,6 @@
         resetNodeSelection();
     }
 
-    vm.changeIncludeDescendants = function () {
-        if (vm.includeDescendants) {
-            for (let i = 0; i < $scope.model.targets.length; i++) {
-                $scope.targets[i].includeDescendants = vm.includeDescendants;
-            }
-        }
-    }
-
     $scope.onTreeInit = function () {
         $scope.dialogTreeApi.callbacks.treeNodeSelect(nodeSelectHandler);
     }
@@ -64,11 +56,14 @@
                     id: "-1",
                     name: "Everything",
                     icon: "icon-item-arrangement",
-                    includeDescendents: true
+                    includeDescendants: true
                 });
 
             } else {
-                $scope.model.target.includeDescendents = vm.includeDescendants;
+                for (let i = 0; i < $scope.model.targets.length; i++) {
+                    
+                    $scope.model.targets[i].includeDescendants = vm.includeDescendants;
+                }
             }
 
             $scope.model.submit($scope.model);

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/selectNode.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/selectNode.controller.js
@@ -1,11 +1,20 @@
 ﻿function selectNodeController($scope) {
-    var vm = this;
-    vm.includeDescendents = false;
+    let vm = this;
+    vm.includeDescendants = false;
     vm.includeEverything = false;
 
     function init() {
         vm.contentType = $scope.model.contentType;
+        $scope.model.targets = [];
         resetNodeSelection();
+    }
+
+    vm.changeIncludeDescendants = function () {
+        if (vm.includeDescendants) {
+            for (let i = 0; i < $scope.model.targets.length; i++) {
+                $scope.targets[i].includeDescendants = vm.includeDescendants;
+            }
+        }
     }
 
     $scope.onTreeInit = function () {
@@ -14,7 +23,7 @@
 
     function resetNodeSelection() {
         $scope.dialogTreeApi = {};
-        $scope.model.target = {};
+        $scope.model.targets = [];
     }
 
     function nodeSelectHandler(args) {
@@ -23,16 +32,22 @@
             args.event.stopPropagation();
         }
 
-        if ($scope.currentNode) {
-            //un-select if there's a current one selected
-            $scope.currentNode.selected = false;
-        }
-
         $scope.currentNode = args.node;
-        $scope.currentNode.selected = true;
-        $scope.model.target.id = args.node.id;
-        $scope.model.target.name = args.node.name;
-        $scope.model.target.icon = args.node.icon;
+
+        // Check if exists already. If it exists, then we remove
+        let existingTargetIndex = $scope.model.targets.findIndex(element => element.id === args.node.id);
+        if (existingTargetIndex > -1) {
+            $scope.model.targets.splice(existingTargetIndex, 1);
+            $scope.currentNode.selected = false;
+        } else {
+            $scope.model.targets.push({
+                id: args.node.id,
+                name: args.node.name,
+                icon: args.node.icon
+            });
+
+            $scope.currentNode.selected = true;
+        }
     }
 
     vm.close = function () {
@@ -44,13 +59,16 @@
     vm.submit = function () {
         if ($scope.model && $scope.model.submit) {
             if (vm.includeEverything) {
-                $scope.model.target.id = "-1";
-                $scope.model.target.name = "Everything";
-                $scope.model.target.icon = "icon-item-arrangement";
-                $scope.model.target.includeDescendents = true;
+                $scope.model.targets = [];
+                $scope.model.targets.push({
+                    id: "-1",
+                    name: "Everything",
+                    icon: "icon-item-arrangement",
+                    includeDescendents: true
+                });
 
             } else {
-                $scope.model.target.includeDescendents = vm.includeDescendents;
+                $scope.model.target.includeDescendents = vm.includeDescendants;
             }
 
             $scope.model.submit($scope.model);

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/seed.view.html
@@ -50,7 +50,7 @@
                                       icon="link.icon"
                                       name="link.name"
                                       published="link.published"
-                                      description="link.includeDescendents ? 'Including descendents' : 'Excluding descendents'"
+                                      description="link.includeDescendants ? 'Including descendants' : 'Excluding descendants'"
                                       sortable="true"
                                       allow-remove="true"
                                       on-remove="vm.removeSelectNode('content', $index)">
@@ -70,7 +70,7 @@
                                       icon="link.icon"
                                       name="link.name"
                                       published="link.published"
-                                      description="link.includeDescendents ? 'Including descendents' : 'Excluding descendents'"
+                                      description="link.includeDescendants ? 'Including descendants' : 'Excluding descendants'"
                                       sortable="true"
                                       allow-remove="true"
                                       on-remove="vm.removeSelectNode('media', $index)">
@@ -90,7 +90,7 @@
                                       icon="link.icon"
                                       name="link.name"
                                       published="link.published"
-                                      description="link.includeDescendents ? 'Including descendents' : 'Excluding descendents'"
+                                      description="link.includeDescendants ? 'Including descendants' : 'Excluding descendants'"
                                       sortable="true"
                                       allow-remove="true"
                                       on-remove="vm.removeSelectNode('dictionary', $index)">

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/selectNode.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/selectNode.html
@@ -20,16 +20,15 @@
                         </umb-checkbox>
                     </div>
                     <div class="umb-control-group" ng-if="!vm.includeEverything">
-                        <h5>Descendents</h5>
-                        <umb-checkbox model="vm.includeDescendents"
-                                      text="Include descendents"
-                                      input-id="includeDescendents"
-                                      ng-click="vm.changeIncludeDescendants()">
+                        <h5>Descendants</h5>
+                        <umb-checkbox model="vm.includeDescendants"
+                                      text="Include descendants"
+                                      input-id="includeDescendants">
                         </umb-checkbox>
                     </div>
 
                     <div class="umb-control-group" ng-if="!vm.includeEverything">
-                        <h5>Node</h5>
+                        <h5>Nodes</h5>
                         <div ng-if="vm.contentType == 'content'">
                             <umb-tree section="content"
                                       treealias="content"

--- a/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/selectNode.html
+++ b/src/Enterspeed.Source.UmbracoCms/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Views/selectNode.html
@@ -23,7 +23,8 @@
                         <h5>Descendents</h5>
                         <umb-checkbox model="vm.includeDescendents"
                                       text="Include descendents"
-                                      input-id="includeDescendents">
+                                      input-id="includeDescendents"
+                                      ng-click="vm.changeIncludeDescendants()">
                         </umb-checkbox>
                     </div>
 

--- a/src/Enterspeed.Source.UmbracoCms/Models/Api/CustomSeed.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Models/Api/CustomSeed.cs
@@ -10,6 +10,6 @@
     public class CustomSeedNode
     {
         public int Id { get; set; }
-        public bool IncludeDescendents { get; set; }
+        public bool IncludeDescendants { get; set; }
     }
 }

--- a/src/Enterspeed.Source.UmbracoCms/Services/EnterspeedJobService.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Services/EnterspeedJobService.cs
@@ -164,7 +164,7 @@ namespace Enterspeed.Source.UmbracoCms.Services
 
                 allContent.Add(contentNode);
 
-                if (contentSeedNode.IncludeDescendents)
+                if (contentSeedNode.IncludeDescendants)
                 {
                     var descendants = _contentService.GetPagedDescendants(contentSeedNode.Id, 0, int.MaxValue, out var total).ToList();
 
@@ -296,7 +296,7 @@ namespace Enterspeed.Source.UmbracoCms.Services
 
                 allDictionaryItems.Add(dictionaryItem);
 
-                if (dictionarySeedNode.IncludeDescendents)
+                if (dictionarySeedNode.IncludeDescendants)
                 {
                     var descendants = _localizationService.GetDictionaryItemDescendants(dictionaryItem.Key).ToList();
 
@@ -378,7 +378,7 @@ namespace Enterspeed.Source.UmbracoCms.Services
 
                 allMediaItems.Add(mediaNode);
 
-                if (mediaSeedNode.IncludeDescendents)
+                if (mediaSeedNode.IncludeDescendants)
                 {
                     var descendants = _mediaService
                         .GetPagedDescendants(mediaSeedNode.Id, 0, int.MaxValue, out _).ToList();


### PR DESCRIPTION
Added support for selecting multiple nodes. 

We are adding an array targets in the dialog view, instead of return a single target. 
Support for this scenario has been set up in both the seed view and select node view. 