### PR TITLE
Feature/3266 value converters needs to resolve links in the correct culture

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+### Updated
+- VariationContext is set to the correct culture in the jobs pipeline
+
 ## [2.5.0 - 2023-06-12]
 ### Addded
 - Added buttons to clear a single or all failed jobs in the failed jobs list

--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.netframework.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.netframework.md
@@ -6,6 +6,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 
 ## [Unreleased]
 ### Updated
+- VariationContext is set to the correct culture in the jobs pipeline
 - Update dpendency to Enterspeed.Source.Sdk v1.0.2
 
 ### Fixed

--- a/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
@@ -27,6 +27,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
         private readonly IUrlFactory _urlFactory;
         private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
         private readonly IPublishedRouter _publishedRouter;
+        private readonly IVariationContextAccessor _variationContextAccessor;
 
         public EnterspeedPreviewContentPublishJobHandler(
             IUmbracoContextFactory umbracoContextFactory,
@@ -37,7 +38,8 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
             IEnterspeedGuardService enterspeedGuardService,
             IUrlFactory urlFactory,
             IEnterspeedConnectionProvider enterspeedConnectionProvider,
-            IPublishedRouter publishedRouter)
+            IPublishedRouter publishedRouter,
+            IVariationContextAccessor variationContextAccessor)
         {
             _umbracoContextFactory = umbracoContextFactory;
             _enterspeedPropertyService = enterspeedPropertyService;
@@ -48,6 +50,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
             _urlFactory = urlFactory;
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
             _publishedRouter = publishedRouter;
+            _variationContextAccessor = variationContextAccessor;
         }
 
         public virtual bool CanHandle(EnterspeedJob job)
@@ -62,6 +65,11 @@ namespace Enterspeed.Source.UmbracoCms.V8.Handlers.PreviewContent
         {
             using (var context = _umbracoContextFactory.EnsureUmbracoContext())
             {
+                if (!string.IsNullOrEmpty(job.Culture))
+                {
+                    _variationContextAccessor.VariationContext = new VariationContext(job.Culture);
+                }
+
                 var content = GetContent(job, context);
                 if (!CanIngest(content, job))
                 {

--- a/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultMultiUrlPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Services/DataProperties/DefaultConverters/DefaultMultiUrlPickerPropertyValueConverter.cs
@@ -92,9 +92,6 @@ namespace Enterspeed.Source.UmbracoCms.V8.Services.DataProperties.DefaultConvert
                     if (content != null)
                     {
                         idProperty = new StringEnterspeedProperty(_entityIdentityService.GetId(content, culture));
-                        url = !string.IsNullOrWhiteSpace(culture)
-                            ? content.Url(culture)
-                            : content.Url(null, UrlMode.Absolute);
                     }
                 }
                 else if (link.Udi.EntityType == "media")

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Content/EnterspeedContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Content/EnterspeedContentPublishJobHandler.cs
@@ -62,8 +62,11 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Content
         {
             using (var context = _umbracoContextFactory.EnsureUmbracoContext())
             {
-                // set variation context, so data is resolved in the correct culture
-                _variationContextAccessor.VariationContext = new VariationContext(job.Culture);
+                if (!string.IsNullOrEmpty(job.Culture))
+                {
+                    // set variation context, so data is resolved in the correct culture
+                    _variationContextAccessor.VariationContext = new VariationContext(job.Culture);
+                }
 
                 var content = GetContent(job, context);
                 if (!CanIngest(content, job))

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/Content/EnterspeedContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/Content/EnterspeedContentPublishJobHandler.cs
@@ -25,6 +25,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Content
         private readonly IEnterspeedGuardService _enterspeedGuardService;
         private readonly IUrlFactory _urlFactory;
         private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
+        private readonly IVariationContextAccessor _variationContextAccessor;
 
         public EnterspeedContentPublishJobHandler(
             IUmbracoContextFactory umbracoContextFactory,
@@ -34,7 +35,8 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Content
             IUmbracoRedirectsService redirectsService,
             IEnterspeedGuardService enterspeedGuardService,
             IUrlFactory urlFactory,
-            IEnterspeedConnectionProvider enterspeedConnectionProvider)
+            IEnterspeedConnectionProvider enterspeedConnectionProvider,
+            IVariationContextAccessor variationContextAccessor)
         {
             _umbracoContextFactory = umbracoContextFactory;
             _enterspeedPropertyService = enterspeedPropertyService;
@@ -44,21 +46,25 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.Content
             _enterspeedGuardService = enterspeedGuardService;
             _urlFactory = urlFactory;
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
+            _variationContextAccessor = variationContextAccessor;
         }
 
         public virtual bool CanHandle(EnterspeedJob job)
         {
             return
-                   _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
-                   && job.EntityType == EnterspeedJobEntityType.Content
-                   && job.JobType == EnterspeedJobType.Publish
-                   && job.ContentState == EnterspeedContentState.Publish;
+                _enterspeedConnectionProvider.GetConnection(ConnectionType.Publish) != null
+                && job.EntityType == EnterspeedJobEntityType.Content
+                && job.JobType == EnterspeedJobType.Publish
+                && job.ContentState == EnterspeedContentState.Publish;
         }
 
         public virtual void Handle(EnterspeedJob job)
         {
             using (var context = _umbracoContextFactory.EnsureUmbracoContext())
             {
+                // set variation context, so data is resolved in the correct culture
+                _variationContextAccessor.VariationContext = new VariationContext(job.Culture);
+
                 var content = GetContent(job, context);
                 if (!CanIngest(content, job))
                 {

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/PreviewContent/EnterspeedPreviewContentPublishJobHandler.cs
@@ -25,6 +25,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
         private readonly IEnterspeedGuardService _enterspeedGuardService;
         private readonly IUrlFactory _urlFactory;
         private readonly IEnterspeedConnectionProvider _enterspeedConnectionProvider;
+        private readonly IVariationContextAccessor _variationContextAccessor;
 
         public EnterspeedPreviewContentPublishJobHandler(
             IUmbracoContextFactory umbracoContextFactory,
@@ -34,7 +35,8 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
             IUmbracoRedirectsService redirectsService,
             IEnterspeedGuardService enterspeedGuardService,
             IUrlFactory urlFactory,
-            IEnterspeedConnectionProvider enterspeedConnectionProvider)
+            IEnterspeedConnectionProvider enterspeedConnectionProvider,
+            IVariationContextAccessor variationContextAccessor)
         {
             _umbracoContextFactory = umbracoContextFactory;
             _enterspeedPropertyService = enterspeedPropertyService;
@@ -44,6 +46,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
             _enterspeedGuardService = enterspeedGuardService;
             _urlFactory = urlFactory;
             _enterspeedConnectionProvider = enterspeedConnectionProvider;
+            _variationContextAccessor = variationContextAccessor;
         }
 
         public virtual bool CanHandle(EnterspeedJob job)
@@ -58,6 +61,12 @@ namespace Enterspeed.Source.UmbracoCms.Handlers.PreviewContent
         {
             using (var context = _umbracoContextFactory.EnsureUmbracoContext())
             {
+                if (!string.IsNullOrEmpty(job.Culture))
+                {
+                    // set variation context, so data is resolved in the correct culture
+                    _variationContextAccessor.VariationContext = new VariationContext(job.Culture);
+                }
+
                 var content = GetContent(job, context);
                 if (!CanIngest(content, job))
                 {

--- a/src/Enterspeed.Source.UmbracoCms/Services/DataProperties/DefaultConverters/DefaultMultiUrlPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Services/DataProperties/DefaultConverters/DefaultMultiUrlPickerPropertyValueConverter.cs
@@ -16,18 +16,15 @@ namespace Enterspeed.Source.UmbracoCms.Services.DataProperties.DefaultConverters
         private readonly IUmbracoContextFactory _umbracoContextFactory;
         private readonly IEntityIdentityService _entityIdentityService;
         private readonly IUmbracoMediaUrlProvider _mediaUrlProvider;
-        private readonly ILogger<DefaultMultiUrlPickerPropertyValueConverter> _logger;
 
         public DefaultMultiUrlPickerPropertyValueConverter(
             IUmbracoContextFactory umbracoContextFactory,
             IEntityIdentityService entityIdentityService,
-            IUmbracoMediaUrlProvider mediaUrlProvider,
-            ILogger<DefaultMultiUrlPickerPropertyValueConverter> logger)
+            IUmbracoMediaUrlProvider mediaUrlProvider)
         {
             _umbracoContextFactory = umbracoContextFactory;
             _entityIdentityService = entityIdentityService;
             _mediaUrlProvider = mediaUrlProvider;
-            _logger = logger;
         }
 
         public bool IsConverter(IPublishedPropertyType propertyType)

--- a/src/Enterspeed.Source.UmbracoCms/Services/DataProperties/DefaultConverters/DefaultMultiUrlPickerPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Services/DataProperties/DefaultConverters/DefaultMultiUrlPickerPropertyValueConverter.cs
@@ -93,8 +93,6 @@ namespace Enterspeed.Source.UmbracoCms.Services.DataProperties.DefaultConverters
                 if (link.Udi.EntityType == "document")
                 {
                     var content = context.Content.GetById(link.Udi);
-                    // link.url always contains the url for the default culture (maybe a bug in Umbraco?), so we resolve the url for the correct culture our self
-                    url = content is not null ? content.GetUrl(_logger, culture, UrlMode.Absolute) : "#";
                     if (content != null)
                     {
                         idProperty = new StringEnterspeedProperty(_entityIdentityService.GetId(content, culture));


### PR DESCRIPTION
**Findings**

```
`Danish node referencing a Danish node from the RTE linkpicker
"/People" before changes "/mennesker" after.

Results before
{
	"sourceId": "gid://Source/bf50bc5a-116e-4a04-b1dc-0bc754e2ab74",
	"id": "gid://Source/bf50bc5a-116e-4a04-b1dc-0bc754e2ab74/Entity/1131-da",
	"type": "contact",
	"originId": "1131-da",
	"originParentId": "1102-en-us",
	"url": "https://localhost:44313/da/kontakt/",
	"redirects": [],
	"properties": {
		"seoMetaDescription": "",
		"keywords": [],
		"umbracoNavihide": false,
		"pageTitle": "Let's have a chat",
		"contactFormHeader": "Send Us A Message",
		"contactIntro": "<p>test <a href=\"/people/\" title=\"Mennesker\" data-anchor=\"#\">Mennesker</a></p>",
		"mapHeader": "You'll find us here",
		"metaData": {
			"name": "Kontakt",
			"culture": "da",
			"domain": null,
			"sortOrder": 4,
			"level": 2,
			"createDate": "2023-06-12T23:10:51",
			"updateDate": "2023-06-17T12:13:07",
			"nodePath": [
				"1102-da",
				"1131-da"
			]
		}
	}
}



Results after
{
	"sourceId": "gid://Source/bf50bc5a-116e-4a04-b1dc-0bc754e2ab74",
	"id": "gid://Source/bf50bc5a-116e-4a04-b1dc-0bc754e2ab74/Entity/1131-da",
	"type": "contact",
	"originId": "1131-da",
	"originParentId": "1102-en-us",
	"url": "https://localhost:44313/da/kontakt/",
	"redirects": [],
	"properties": {
		"seoMetaDescription": "",
		"keywords": [],
		"umbracoNavihide": false,
		"pageTitle": "Let's have a chat",
		"contactFormHeader": "Send Us A Message",
		"contactIntro": "<p>test <a href=\"/da/mennesker/\" title=\"Mennesker\" data-anchor=\"#\">Mennesker</a></p>",
		"mapHeader": "You'll find us here",
		"metaData": {
			"name": "Kontakt",
			"culture": "da",
			"domain": null,
			"sortOrder": 4,
			"level": 2,
			"createDate": "2023-06-12T23:10:51",
			"updateDate": "2023-06-17T12:18:24",
			"nodePath": [
				"1102-da",
				"1131-da"
			]
		}
	}
}


Danish node referencing a Danish node from a RTE component, using link picker in the rte,  in a grid block.
"/da/produkt"
{
	"sourceId": "gid://Source/bf50bc5a-116e-4a04-b1dc-0bc754e2ab74",
	"id": "gid://Source/bf50bc5a-116e-4a04-b1dc-0bc754e2ab74/Entity/1127-da",
	"type": "blog",
	"originId": "1127-da",
	"originParentId": "1102-en-us",
	"url": "https://localhost:44313/da/blog/",
	"redirects": [],
	"properties": {
		"pageTitle": "Behind The Scenes",
		"bodyText": {
			"items": [
				{
					"content": {
						"richText": "<p><a href=\"/da/produkt/\" title=\"Produkt\" data-anchor=\"#\">Produkt</a></p>"
					},
					"contentType": "umbBlockGridDemoRichTextBlock",
					"columnSpan": 12,
					"rowSpan": 1
				}
			]
		},
		"seoMetaDescription": "",
		"keywords": [],
		"umbracoNavihide": false,
		"howManyPostsShouldBeShown": 2,
		"disqusShortname": "",
		"metaData": {
			"name": "Blog",
			"culture": "da",
			"domain": null,
			"sortOrder": 3,
			"level": 2,
			"createDate": "2023-06-12T23:10:51",
			"updateDate": "2023-06-17T20:08:52",
			"nodePath": [
				"1102-da",
				"1127-da"
			]
		}
	}
}
```