### PR TITLE
Feature/3244 enterspeed jobs table locked when jobs are being processed

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V8/Data/Repositories/EnterspeedJobRespository.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V8/Data/Repositories/EnterspeedJobRespository.cs
@@ -98,7 +98,7 @@ namespace Enterspeed.Source.UmbracoCms.V8.Data.Repositories
                 return;
             }
 
-            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
+            using (var scope = _scopeProvider.CreateScope())
             {
                 foreach (var job in jobs)
                 {
@@ -106,16 +106,20 @@ namespace Enterspeed.Source.UmbracoCms.V8.Data.Repositories
                     scope.Database.Save(jobToSave);
                     job.Id = jobToSave.Id;
                 }
+
+                scope.Complete();
             }
         }
 
         public void Delete(IList<int> ids)
         {
-            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
+            using (var scope = _scopeProvider.CreateScope())
             {
                 scope.Database.DeleteMany<EnterspeedJobSchema>()
                     .Where(x => ids.Contains(x.Id))
                     .Execute();
+
+                scope.Complete();
             }
         }
     }

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
@@ -17,22 +17,19 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
         private readonly EnterspeedJobHandlerCollection _jobHandlers;
         private readonly IEnterspeedJobFactory _enterspeedJobFactory;
         private readonly IEnterspeedPostJobsHandler _enterspeedPostJobsHandler;
-        private readonly IScopeProvider _scopeProvider;
 
         public EnterspeedJobsHandler(
             IEnterspeedJobRepository enterspeedJobRepository,
             ILogger<EnterspeedJobsHandler> logger,
             EnterspeedJobHandlerCollection jobHandlers,
             IEnterspeedJobFactory enterspeedJobFactory,
-            IEnterspeedPostJobsHandler enterspeedPostJobsHandler,
-            IScopeProvider scopeProvider)
+            IEnterspeedPostJobsHandler enterspeedPostJobsHandler)
         {
             _enterspeedJobRepository = enterspeedJobRepository;
             _logger = logger;
             _jobHandlers = jobHandlers;
             _enterspeedJobFactory = enterspeedJobFactory;
             _enterspeedPostJobsHandler = enterspeedPostJobsHandler;
-            _scopeProvider = scopeProvider;
         }
 
         /// <summary>
@@ -52,11 +49,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
             ICollection<EnterspeedJob> newFailedJobs, IList<EnterspeedJob> existingFailedJobsToDelete)
         {
             // Fetch all failed jobs for these content ids. We need to do this to delete the failed jobs if they no longer fails
-            List<EnterspeedJob> failedJobsToHandle;
-            using (_scopeProvider.CreateScope(autoComplete: true))
-            {
-                failedJobsToHandle = _enterspeedJobRepository.GetFailedJobs(jobsToProcess.Select(x => x.EntityId).Distinct().ToList()).ToList();
-            }
+            var failedJobsToHandle = _enterspeedJobRepository.GetFailedJobs(jobsToProcess.Select(x => x.EntityId).Distinct().ToList()).ToList();
 
             var jobsByEntityIdAndContentState = jobsToProcess.GroupBy(x => new { x.EntityId, x.ContentState, x.Culture });
             foreach (var jobInfo in jobsByEntityIdAndContentState)

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedJobsHandler.cs
@@ -6,6 +6,7 @@ using Enterspeed.Source.UmbracoCms.Data.Repositories;
 using Enterspeed.Source.UmbracoCms.Factories;
 using Lucene.Net.Util;
 using Microsoft.Extensions.Logging;
+using Umbraco.Cms.Core.Scoping;
 
 namespace Enterspeed.Source.UmbracoCms.Handlers
 {
@@ -16,19 +17,22 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
         private readonly EnterspeedJobHandlerCollection _jobHandlers;
         private readonly IEnterspeedJobFactory _enterspeedJobFactory;
         private readonly IEnterspeedPostJobsHandler _enterspeedPostJobsHandler;
+        private readonly IScopeProvider _scopeProvider;
 
         public EnterspeedJobsHandler(
             IEnterspeedJobRepository enterspeedJobRepository,
             ILogger<EnterspeedJobsHandler> logger,
             EnterspeedJobHandlerCollection jobHandlers,
             IEnterspeedJobFactory enterspeedJobFactory,
-            IEnterspeedPostJobsHandler enterspeedPostJobsHandler)
+            IEnterspeedPostJobsHandler enterspeedPostJobsHandler,
+            IScopeProvider scopeProvider)
         {
             _enterspeedJobRepository = enterspeedJobRepository;
             _logger = logger;
             _jobHandlers = jobHandlers;
             _enterspeedJobFactory = enterspeedJobFactory;
             _enterspeedPostJobsHandler = enterspeedPostJobsHandler;
+            _scopeProvider = scopeProvider;
         }
 
         /// <summary>
@@ -48,13 +52,13 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
             ICollection<EnterspeedJob> newFailedJobs, IList<EnterspeedJob> existingFailedJobsToDelete)
         {
             // Fetch all failed jobs for these content ids. We need to do this to delete the failed jobs if they no longer fails
-            // TODO: Not a fan of assigning this variable here and parsing it around. Refactor?
-            var failedJobsToHandle =
-                _enterspeedJobRepository.GetFailedJobs(jobsToProcess.Select(x => x.EntityId).Distinct().ToList());
+            List<EnterspeedJob> failedJobsToHandle;
+            using (_scopeProvider.CreateScope(autoComplete: true))
+            {
+                failedJobsToHandle = _enterspeedJobRepository.GetFailedJobs(jobsToProcess.Select(x => x.EntityId).Distinct().ToList()).ToList();
+            }
 
-            var jobsByEntityIdAndContentState =
-                jobsToProcess.GroupBy(x => new { x.EntityId, x.ContentState, x.Culture });
-
+            var jobsByEntityIdAndContentState = jobsToProcess.GroupBy(x => new { x.EntityId, x.ContentState, x.Culture });
             foreach (var jobInfo in jobsByEntityIdAndContentState)
             {
                 // Get newest job to handle

--- a/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedPostJobsHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/Handlers/EnterspeedPostJobsHandler.cs
@@ -21,7 +21,6 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
         private readonly EnterspeedJobHandlerCollection _enterspeedJobHandlerCollection;
         private readonly ILogger<EnterspeedPostJobsHandler> _logger;
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
-        private readonly IScopeProvider _scopeProvider;
 
 
         public EnterspeedPostJobsHandler(IEnterspeedJobRepository enterspeedJobRepository,
@@ -30,7 +29,7 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
             ILocalizationService localizationService,
             EnterspeedJobHandlerCollection enterspeedJobHandlerCollection,
             ILogger<EnterspeedPostJobsHandler> logger,
-            IEnterspeedConfigurationService enterspeedConfigurationService, IScopeProvider scopeProvider)
+            IEnterspeedConfigurationService enterspeedConfigurationService)
         {
             _enterspeedJobRepository = enterspeedJobRepository;
             _enterspeedJobFactory = enterspeedJobFactory;
@@ -39,7 +38,6 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
             _enterspeedJobHandlerCollection = enterspeedJobHandlerCollection;
             _logger = logger;
             _enterspeedConfigurationService = enterspeedConfigurationService;
-            _scopeProvider = scopeProvider;
         }
 
         /// <summary>
@@ -52,22 +50,17 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
             IReadOnlyCollection<EnterspeedJob> existingFailedJobsToDelete,
             IList<EnterspeedJob> newFailedJobs)
         {
-            using (var scope = _scopeProvider.CreateScope())
+            if (!_enterspeedConfigurationService.IsRootDictionariesDisabled())
             {
-                if (!_enterspeedConfigurationService.IsRootDictionariesDisabled())
-                {
-                    HandleRootDictionaries(processedJobs);
-                }
-
-                HandleProcessedJobs(processedJobs);
-                HandleExistingFailedJobs(existingFailedJobsToDelete);
-
-                // WARNING: This throws an exception if any new failed jobs. This should should not be called before any other method
-                // TODO: Handle in a different way?
-                HandleFailedJobs(newFailedJobs);
-
-                scope.Complete();
+                HandleRootDictionaries(processedJobs);
             }
+
+            HandleProcessedJobs(processedJobs);
+            HandleExistingFailedJobs(existingFailedJobsToDelete);
+
+            // WARNING: This throws an exception if any new failed jobs. This should should not be called before any other method
+            // TODO: Handle in a different way?
+            HandleFailedJobs(newFailedJobs);
         }
 
         /// <summary>
@@ -133,7 +126,6 @@ namespace Enterspeed.Source.UmbracoCms.Handlers
                 }
             }
         }
-
 
         /// <summary>
         /// Jobs that failed while processing are being created or updated in the database.

--- a/src/Enterspeed.Source.UmbracoCms/HostedServices/HandleEnterspeedJobsHostedService.cs
+++ b/src/Enterspeed.Source.UmbracoCms/HostedServices/HandleEnterspeedJobsHostedService.cs
@@ -9,6 +9,7 @@ using Umbraco.Cms.Core.Sync;
 using Umbraco.Cms.Infrastructure.HostedServices;
 #if NET5_0
 using Umbraco.Cms.Core.Scoping;
+
 #else
 using Umbraco.Cms.Infrastructure.Scoping;
 #endif
@@ -35,7 +36,6 @@ namespace Enterspeed.Source.UmbracoCms.HostedServices
                 var logger = serviceProvider.GetRequiredService<ILogger<HandleEnterspeedJobsHostedService>>();
                 var serverRoleAccessor = serviceProvider.GetRequiredService<IServerRoleAccessor>();
                 var configurationService = serviceProvider.GetRequiredService<IEnterspeedConfigurationService>();
-                var scopeProvider = serviceProvider.GetRequiredService<IScopeProvider>();
 
                 // Don't do anything if the site is not running.
                 if (runtimeState.Level != RuntimeLevel.Run)
@@ -50,11 +50,7 @@ namespace Enterspeed.Source.UmbracoCms.HostedServices
 
                 if (serverRoleAccessor.CurrentServerRole == ServerRole.SchedulingPublisher || serverRoleAccessor.CurrentServerRole == ServerRole.Single)
                 {
-                    // Handle jobs in batches of 50
-                    using (var scope = scopeProvider.CreateScope(autoComplete: true))
-                    {
-                        enterspeedJobsHandlingService.HandlePendingJobs(50);
-                    }
+                    enterspeedJobsHandlingService.HandlePendingJobs(50);
                 }
                 else
                 {

--- a/src/Enterspeed.Source.UmbracoCms/NotificationHandlers/BaseEnterspeedNotificationHandler.cs
+++ b/src/Enterspeed.Source.UmbracoCms/NotificationHandlers/BaseEnterspeedNotificationHandler.cs
@@ -57,10 +57,7 @@ namespace Enterspeed.Source.UmbracoCms.NotificationHandlers
                 return;
             }
 
-            using (var scope = _scopeProvider.CreateScope(autoComplete: true))
-            {
-                _enterspeedJobRepository.Save(jobs);
-            }
+            _enterspeedJobRepository.Save(jobs);
 
             using (_umbracoContextFactory.EnsureUmbracoContext())
             {
@@ -78,10 +75,7 @@ namespace Enterspeed.Source.UmbracoCms.NotificationHandlers
             // Do not continue if the scope did not complete - the transaction may have been canceled and rolled back
             if (scopeCompleted)
             {
-                using (_scopeProvider.CreateScope(autoComplete: true))
-                {
-                    _enterspeedJobsHandlingService.HandleJobs(jobs);
-                }
+                _enterspeedJobsHandlingService.HandleJobs(jobs);
             }
         }
     }


### PR DESCRIPTION
Moving database interactions out to seperate scopes. This is done to avoid deadlocking the database, since the transaction until now has been waiting for interactions with the ingest api. 