### PR TITLE
Added support for Single block mode

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -4,13 +4,25 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.1.0 - UNRELEASED]
+### Added
+- Added support for Single block mode for Block Lists
+
 ## [5.0.0 - 2024-10-03]
 ### Added
-- Added Umbraco 14 support.
+- Added Umbraco 14 support
 
 ### Breaking
-- Umbraco.Source.Cms namespace has been updated to Umbraco.Source.Cms.Base.
-- EnterspeedComposer must now be referenced on `Enterspeed.Source.UmbracoCms.V14Plus.EnterspeedComposer` and `Enterspeed.Source.UmbracoCms.V9Plus.EnterspeedComposer`.
+- `Umbraco.Source.Cms namespace` has been updated to `Umbraco.Source.Cms.Base`
+- `EnterspeedComposer` must now be referenced on `Enterspeed.Source.UmbracoCms.V14Plus.EnterspeedComposer`
+
+## [4.3.0 - UNRELEASED]
+### Added
+- Added support for Single block mode for Block Lists
+
+### Breaking
+- `Umbraco.Source.Cms` namespace has been updated to `Umbraco.Source.Cms.Base`
+- `EnterspeedComposer` must now be referenced on `Enterspeed.Source.UmbracoCms.V9Plus.EnterspeedComposer`
 
 ## [4.2.1 - 2024-01-31]
 ### Fixed


### PR DESCRIPTION
If Single block mode is enabled, Umbraco will not return a `blockListModel` but a single `blockListItem`.
![image](https://github.com/user-attachments/assets/3b138c9e-3830-4e98-86d1-2e59bd755c88)
