### PR TITLE
Introduced BaseUrl instead of Endpoint to align configuration and made it optional

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0 - xxxx-xx-xx]
+### Added
+- Added JSON schema file to provide IntelliSense in appsettings.json for Enterspeed settings
+
 ## [5.2.0 - 2024-12-03]
 ### Added
 - Added support for new RTE
@@ -23,6 +27,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Breaking
 - `Umbraco.Source.Cms namespace` has been updated to `Umbraco.Source.Cms.Base`
 - `EnterspeedComposer` must now be referenced on `Enterspeed.Source.UmbracoCms.V14Plus.EnterspeedComposer`
+
+## [4.4.0 - xxxx-xx-xx]
+### Added
+- Added JSON schema file to provide IntelliSense in appsettings.json for Enterspeed settings
 
 ## [4.3.0 - 2024-12-10]
 ### Added

--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -7,6 +7,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [5.3.0 - xxxx-xx-xx]
 ### Added
 - Added JSON schema file to provide IntelliSense in appsettings.json for Enterspeed settings
+- Introduced `BaseUrl` as a replacement for `Endpoint` to align configuration between this package and `Enterspeed.Source.Sdk`
 
 ## [5.2.0 - 2024-12-03]
 ### Added
@@ -31,6 +32,7 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ## [4.4.0 - xxxx-xx-xx]
 ### Added
 - Added JSON schema file to provide IntelliSense in appsettings.json for Enterspeed settings
+- Introduced `BaseUrl` as a replacement for `Endpoint` to align configuration between this package and `Enterspeed.Source.Sdk`
 
 ## [4.3.0 - 2024-12-10]
 ### Added

--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/JsonSchema/appsettings-schema.enterspeed.json
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/JsonSchema/appsettings-schema.enterspeed.json
@@ -6,9 +6,10 @@
     "Enterspeed": {
       "type": "object",
       "properties": {
-        "Endpoint": {
+        "BaseUrl": {
           "type": "string",
-          "description": "Specifies the base url for ingest endpoint."
+          "description": "Specifies a custom base url for ingest endpoint.",
+          "default": "https://api.enterspeed.com"
         },
         "ApiKey ": {
           "type": "string",
@@ -48,7 +49,7 @@
           "default": false
         }
       },
-      "required": [ "Endpoint", "ApiKey" ]
+      "required": [ "ApiKey" ]
     }
   }
 }

--- a/src/Enterspeed.Source.UmbracoCms.V9Plus/JsonSchema/appsettings-schema.enterspeed.json
+++ b/src/Enterspeed.Source.UmbracoCms.V9Plus/JsonSchema/appsettings-schema.enterspeed.json
@@ -6,9 +6,10 @@
     "Enterspeed": {
       "type": "object",
       "properties": {
-        "Endpoint": {
+        "BaseUrl": {
           "type": "string",
-          "description": "Specifies the base url for ingest endpoint."
+          "description": "Specifies a custom base url for ingest endpoint.",
+          "default": "https://api.enterspeed.com"
         },
         "ApiKey ": {
           "type": "string",
@@ -48,7 +49,7 @@
           "default": false
         }
       },
-      "required": [ "Endpoint", "ApiKey" ]
+      "required": [ "ApiKey" ]
     }
   }
 }


### PR DESCRIPTION
Based on PR from Adrian (https://github.com/enterspeedhq/enterspeed-source-umbraco-cms/pull/161) and issues with a wrong configuration.

We should align configuration property names to avoid confusion.

In `Enterspeed.Source.SDK` the configuration property is called `BaseUrl`, the same name is use in the C# configuration class in the `Enterspeed.Source.UmbracoCms` how ever the value is read from appsettings.json from a property called `Endpoint`.

This should be align to `BaseUrl` but with `Endpoint` as fallback to avoid a breaking change.