### PR TITLE
Fixed culture handling for parent name change

### DIFF
--- a/CHANGELOG-Enterspeed.Source.UmbracoCms.md
+++ b/CHANGELOG-Enterspeed.Source.UmbracoCms.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [5.3.0 - xxxx-xx-xx]
+### Fixed
+- Fixed culture handling when rename of node should update urls on all descendants in Enterspeed sources.
+
 ## [5.3.0 - 2025-01-27]
 ### Added
 - Added JSON schema file to provide IntelliSense in appsettings.json for Enterspeed settings
@@ -28,6 +32,10 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 ### Breaking
 - `Umbraco.Source.Cms namespace` has been updated to `Umbraco.Source.Cms.Base`
 - `EnterspeedComposer` must now be referenced on `Enterspeed.Source.UmbracoCms.V14Plus.EnterspeedComposer`
+
+## [4.4.1 - xxxx-xx-xx]
+### Fixed
+- Fixed culture handling when rename of node should update urls on all descendants in Enterspeed sources.
 
 ## [4.4.0 - 2025-01-27]
 ### Added


### PR DESCRIPTION
Name comparison was always done against the default culture, which means we compared names from different cultures.

This means that whenever you change a node in non-default culture, it would always detect the name as changed (is name was different in the two cultures) and ingest all descendents.