### PR TITLE
Fix bug with context being null, when blocks are rendered in RTE as background job

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.Base/Extensions/UmbracoBuilderExtensions.cs
+++ b/src/Enterspeed.Source.UmbracoCms.Base/Extensions/UmbracoBuilderExtensions.cs
@@ -49,6 +49,7 @@ namespace Enterspeed.Source.UmbracoCms.Base.Extensions
             builder.Services.AddTransient<IUmbracoContextProvider, UmbracoContextProvider>();
             builder.Services.AddTransient<IUmbracoMediaUrlProvider, UmbracoMediaUrlProvider>();
             builder.Services.AddTransient<IEnterspeedJobRepository, EnterspeedJobRepository>();
+            builder.Services.AddTransient<IEnterspeedHttpContextProvider, EnterspeedHttpContextProvider>();
             builder.Services.AddTransient<IUmbracoUrlService, UmbracoUrlService>();
             builder.Services.AddTransient<IEnterspeedJobService, EnterspeedJobService>();
             builder.Services.AddTransient<IUmbracoRedirectsService, UmbracoRedirectsService>();
@@ -193,7 +194,7 @@ namespace Enterspeed.Source.UmbracoCms.Base.Extensions
             builder.AddNotificationHandler<MediaMovedNotification, EnterspeedMediaMovedEventHandler>();
             builder.AddNotificationHandler<MediaMovedToRecycleBinNotification, EnterspeedMediaTrashedNotificationHandler>();
             builder.AddNotificationHandler<ContentSavingNotification, EnterspeedContentSavingNotificationHandler>();
-         
+
             // Components
             builder.Components().Append<EnterspeedJobsComponent>();
 

--- a/src/Enterspeed.Source.UmbracoCms.Base/Providers/EnterspeedHttpContextProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.Base/Providers/EnterspeedHttpContextProvider.cs
@@ -1,0 +1,63 @@
+﻿using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using System;
+
+namespace Enterspeed.Source.UmbracoCms.Base.Providers
+{
+    public class EnterspeedHttpContextProvider : IEnterspeedHttpContextProvider
+    {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IServiceProvider _serviceProvider;
+
+        public EnterspeedHttpContextProvider(
+            IHttpContextAccessor httpContextAccessor,
+            IServiceProvider serviceProvider)
+        {
+            _httpContextAccessor = httpContextAccessor;
+            _serviceProvider = serviceProvider;
+        }
+
+        public IDisposable CreateFakeHttpContext()
+        {
+            var httpContext = new DefaultHttpContext
+            {
+                Request =
+                {
+                    Scheme = "https",
+                    Host = new HostString("enterspeed.com")
+                }
+            };
+
+            var scope = _serviceProvider.CreateScope();
+            httpContext.RequestServices = scope.ServiceProvider;
+
+            var originalContext = _httpContextAccessor.HttpContext;
+            _httpContextAccessor.HttpContext = httpContext;
+
+            return new HttpContextScope(_httpContextAccessor, originalContext, scope);
+        }
+
+        private class HttpContextScope : IDisposable
+        {
+            private readonly IHttpContextAccessor _httpContextAccessor;
+            private readonly HttpContext _originalContext;
+            private readonly IServiceScope _scope;
+
+            public HttpContextScope(
+                IHttpContextAccessor httpContextAccessor,
+                HttpContext originalContext,
+                IServiceScope scope)
+            {
+                _httpContextAccessor = httpContextAccessor;
+                _originalContext = originalContext;
+                _scope = scope;
+            }
+
+            public void Dispose()
+            {
+                _httpContextAccessor.HttpContext = _originalContext;
+                _scope.Dispose();
+            }
+        }
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.Base/Providers/IEnterspeedHttpContextProvider.cs
+++ b/src/Enterspeed.Source.UmbracoCms.Base/Providers/IEnterspeedHttpContextProvider.cs
@@ -1,0 +1,9 @@
+﻿using System;
+
+namespace Enterspeed.Source.UmbracoCms.Base.Providers
+{
+    public interface IEnterspeedHttpContextProvider
+    {
+        IDisposable CreateFakeHttpContext();
+    }
+}

--- a/src/Enterspeed.Source.UmbracoCms.Base/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.Base/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
@@ -1,18 +1,32 @@
 ﻿using Enterspeed.Source.Sdk.Api.Models.Properties;
 using Enterspeed.Source.UmbracoCms.Base.Extensions;
+using Enterspeed.Source.UmbracoCms.Base.Providers;
+using Microsoft.AspNetCore.Http;
 using Umbraco.Cms.Core.Models.PublishedContent;
+using Umbraco.Cms.Core.Web;
 
 namespace Enterspeed.Source.UmbracoCms.Base.Services.DataProperties.DefaultConverters
 {
     public class DefaultRichTextEditorPropertyValueConverter : IEnterspeedPropertyValueConverter
     {
+        private readonly IHttpContextAccessor _httpContextAccessor;
+        private readonly IUmbracoContextFactory _umbracoContextAccessor;
         private readonly IUmbracoRichTextParser _umbracoRichTextParser;
         private readonly IEnterspeedConfigurationService _enterspeedConfigurationService;
+        private readonly IEnterspeedHttpContextProvider _enterspeedHttpContextProvider;
 
-        public DefaultRichTextEditorPropertyValueConverter(IUmbracoRichTextParser umbracoRichTextParser, IEnterspeedConfigurationService enterspeedConfigurationService)
+        public DefaultRichTextEditorPropertyValueConverter(
+           IHttpContextAccessor httpContextAccessor,
+           IUmbracoContextFactory umbracoContextAccessor,
+           IUmbracoRichTextParser umbracoRichTextParser,
+           IEnterspeedConfigurationService enterspeedConfigurationService,
+           IEnterspeedHttpContextProvider enterspeedHttpContextProvider)
         {
+            _httpContextAccessor = httpContextAccessor;
+            _umbracoContextAccessor = umbracoContextAccessor;
             _umbracoRichTextParser = umbracoRichTextParser;
             _enterspeedConfigurationService = enterspeedConfigurationService;
+            _enterspeedHttpContextProvider = enterspeedHttpContextProvider;
         }
 
         public bool IsConverter(IPublishedPropertyType propertyType)
@@ -21,6 +35,22 @@ namespace Enterspeed.Source.UmbracoCms.Base.Services.DataProperties.DefaultConve
         }
 
         public virtual IEnterspeedProperty Convert(IPublishedProperty property, string culture)
+        {
+            if (_httpContextAccessor.HttpContext == null)
+            {
+                using (_enterspeedHttpContextProvider.CreateFakeHttpContext())
+                {
+                    using (_umbracoContextAccessor.EnsureUmbracoContext())
+                    {
+                        return ConvertWithContext(property, culture);
+                    }
+                }
+            }
+
+            return ConvertWithContext(property, culture);
+        }
+
+        private IEnterspeedProperty ConvertWithContext(IPublishedProperty property, string culture)
         {
             var value = property.GetValue<Umbraco.Cms.Core.Strings.HtmlEncodedString>(culture).ToString();
             value = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(value, _enterspeedConfigurationService.GetConfiguration().MediaDomain);

--- a/src/Enterspeed.Source.UmbracoCms.Base/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
+++ b/src/Enterspeed.Source.UmbracoCms.Base/Services/DataProperties/DefaultConverters/DefaultRichTextEditorPropertyValueConverter.cs
@@ -16,11 +16,11 @@ namespace Enterspeed.Source.UmbracoCms.Base.Services.DataProperties.DefaultConve
         private readonly IEnterspeedHttpContextProvider _enterspeedHttpContextProvider;
 
         public DefaultRichTextEditorPropertyValueConverter(
-           IHttpContextAccessor httpContextAccessor,
-           IUmbracoContextFactory umbracoContextAccessor,
-           IUmbracoRichTextParser umbracoRichTextParser,
-           IEnterspeedConfigurationService enterspeedConfigurationService,
-           IEnterspeedHttpContextProvider enterspeedHttpContextProvider)
+            IHttpContextAccessor httpContextAccessor,
+            IUmbracoContextFactory umbracoContextAccessor,
+            IUmbracoRichTextParser umbracoRichTextParser,
+            IEnterspeedConfigurationService enterspeedConfigurationService,
+            IEnterspeedHttpContextProvider enterspeedHttpContextProvider)
         {
             _httpContextAccessor = httpContextAccessor;
             _umbracoContextAccessor = umbracoContextAccessor;
@@ -31,29 +31,24 @@ namespace Enterspeed.Source.UmbracoCms.Base.Services.DataProperties.DefaultConve
 
         public bool IsConverter(IPublishedPropertyType propertyType)
         {
-            return propertyType.EditorAlias.Equals("Umbraco.TinyMCE") || propertyType.EditorAlias.Equals("Umbraco.RichText");
+            return propertyType.EditorAlias.Equals("Umbraco.TinyMCE") ||
+                   propertyType.EditorAlias.Equals("Umbraco.RichText");
         }
 
         public virtual IEnterspeedProperty Convert(IPublishedProperty property, string culture)
         {
-            if (_httpContextAccessor.HttpContext == null)
-            {
-                using (_enterspeedHttpContextProvider.CreateFakeHttpContext())
-                {
-                    using (_umbracoContextAccessor.EnsureUmbracoContext())
-                    {
-                        return ConvertWithContext(property, culture);
-                    }
-                }
-            }
-
-            return ConvertWithContext(property, culture);
+            if (_httpContextAccessor.HttpContext != null) return ConvertWithContext(property, culture);
+            
+            using (_enterspeedHttpContextProvider.CreateFakeHttpContext())
+            using (_umbracoContextAccessor.EnsureUmbracoContext())
+                return ConvertWithContext(property, culture);
         }
 
         private IEnterspeedProperty ConvertWithContext(IPublishedProperty property, string culture)
         {
             var value = property.GetValue<Umbraco.Cms.Core.Strings.HtmlEncodedString>(culture).ToString();
-            value = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(value, _enterspeedConfigurationService.GetConfiguration().MediaDomain);
+            value = _umbracoRichTextParser.PrefixRelativeImagesWithDomain(value,
+                _enterspeedConfigurationService.GetConfiguration().MediaDomain);
             return new StringEnterspeedProperty(property.Alias, value);
         }
     }


### PR DESCRIPTION
Part of 
https://app.shortcut.com/enterspeed/story/6634/allow-blocks-to-be-part-of-rte-converter-umbraco-connector
https://app.shortcut.com/enterspeed/story/6636/httpcontext-is-null-error-when-block-or-macro-is-rendered-in-rte-converter-in-background-job-umbraco-connector