### PR TITLE
chore: [sc-8619] Umbraco Package: Replace deprecated tryExecuteAndNotify with tryExecute before Umbraco 18.0.0

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/dashboards/settings/settings-dashboard.ts
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/dashboards/settings/settings-dashboard.ts
@@ -58,7 +58,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
         this.#notificationContext?.peek("danger", {
           data: {
             headline: "Error loading configuration",
-            message: error.data.message,
+            message: error?.data?.message ?? error?.message ?? "An unexpected error occurred",
           },
         });
       });
@@ -97,7 +97,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
         this.#notificationContext?.peek("danger", {
           data: {
             headline: "Connection failed",
-            message: error.data.message,
+            message: error?.data?.message ?? error?.message ?? "An unexpected error occurred",
           },
         });
       });
@@ -125,7 +125,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
           this.#notificationContext?.peek("danger", {
             data: {
               headline: "Error saving configuration",
-              message: error.data.message,
+              message: error?.data?.message ?? error?.message ?? "An unexpected error occurred",
             },
           });
         });

--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/repository/enterspeed.repository.ts
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/repository/enterspeed.repository.ts
@@ -1,6 +1,6 @@
 import { UmbControllerBase } from "@umbraco-cms/backoffice/class-api";
 import { UmbControllerHost } from "@umbraco-cms/backoffice/controller-api";
-import { tryExecuteAndNotify } from "@umbraco-cms/backoffice/resources";
+import { tryExecute } from "@umbraco-cms/backoffice/resources";
 import {
   CustomSeedModel,
   DashboardResource,
@@ -13,12 +13,24 @@ export class EnterspeedRepository extends UmbControllerBase {
     super(host);
   }
 
-  // Normalizes the response from tryExecuteAndNotify which differs between Umbraco versions.
+  // Umbraco 14-16: tryExecute(promise) — no host, returns { data: T, error? }
+  // Umbraco 17+:   tryExecute(host, promise, options?) — host required
+  // We detect the version by checking the function's arity and call accordingly.
+  private async executeResource<T>(promise: Promise<T>): Promise<any> {
+    return (tryExecute as any).length >= 2
+      ? (tryExecute as any)(this._host, promise, { disableNotifications: true })
+      : (tryExecute as any)(promise);
+  }
+
+  // Normalizes the response which differs between Umbraco versions.
   // Umbraco 14-15 (UmbDataSourceResponse<T>): wraps result as { data: T, error? }
   // Umbraco 16+   (UmbApiResponse<T> = T & { error? }): returns T directly with error intersected
   // We normalize to the { data, error } shape so all callers work across versions.
   private normalizeResponse(result: any): any {
-    if (result != null && 'isSuccess' in result) {
+    if (result == null) return result;
+    // U16+/U17: result IS the data (no wrapping 'data' property)
+    // ApiResponse types have 'isSuccess'; Response types have 'success' but not 'data'
+    if ('isSuccess' in result || ('success' in result && !('data' in result))) {
       return { data: result, error: result.error };
     }
     return result;
@@ -26,14 +38,13 @@ export class EnterspeedRepository extends UmbControllerBase {
 
   async seed() {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(this._host, DashboardResource.seed())
+      await this.executeResource(DashboardResource.seed())
     );
   }
 
   async customSeed(customSeedModel: CustomSeedModel) {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
+      await this.executeResource(
         DashboardResource.customSeed({ requestBody: customSeedModel })
       )
     );
@@ -41,28 +52,19 @@ export class EnterspeedRepository extends UmbControllerBase {
 
   async clearPendingJobs() {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
-        DashboardResource.clearPendingJobs()
-      )
+      await this.executeResource(DashboardResource.clearPendingJobs())
     );
   }
 
   async getNumberOfPendingJobs() {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
-        DashboardResource.getNumberOfPendingJobs()
-      )
+      await this.executeResource(DashboardResource.getNumberOfPendingJobs())
     );
   }
 
   async getEnterspeedConfiguration() {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
-        DashboardResource.getEnterspeedConfiguration()
-      )
+      await this.executeResource(DashboardResource.getEnterspeedConfiguration())
     );
   }
 
@@ -70,8 +72,7 @@ export class EnterspeedRepository extends UmbControllerBase {
     enterspeedUmbracoConfiguration: EnterspeedUmbracoConfiguration
   ) {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
+      await this.executeResource(
         DashboardResource.testConfigurationConnection({
           requestBody: enterspeedUmbracoConfiguration,
         })
@@ -83,8 +84,7 @@ export class EnterspeedRepository extends UmbControllerBase {
     enterspeedUmbracoConfiguration: EnterspeedUmbracoConfiguration
   ) {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
+      await this.executeResource(
         DashboardResource.saveConfiguration({
           requestBody: enterspeedUmbracoConfiguration,
         })
@@ -94,17 +94,13 @@ export class EnterspeedRepository extends UmbControllerBase {
 
   async getFailedJobs() {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
-        DashboardResource.getFailedJobs()
-      )
+      await this.executeResource(DashboardResource.getFailedJobs())
     );
   }
 
   public async deleteSelectedFailedJobs(ids: JobIdsToDelete) {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
+      await this.executeResource(
         DashboardResource.deleteJobs({ requestBody: ids })
       )
     );
@@ -112,10 +108,7 @@ export class EnterspeedRepository extends UmbControllerBase {
 
   public async deleteFailedJobs() {
     return this.normalizeResponse(
-      await tryExecuteAndNotify(
-        this._host,
-        DashboardResource.deleteFailedJobs()
-      )
+      await this.executeResource(DashboardResource.deleteFailedJobs())
     );
   }
 }


### PR DESCRIPTION
## Problem
In Umbraco 17, the Enterspeed settings dashboard failed silently when saving configuration — no success toast was shown, and the following error appeared in the browser console (it did however save the changes):

```
TypeError: Cannot read properties of undefined (reading 'message')
    at settings-dashboard.ts:128
```

Additionally, all interactions with the settings dashboard triggered a deprecation warning:

```
Umbraco Backoffice: The tryExecuteAndNotify function is deprecated.
The feature will be removed in version 18.0.0. Use the tryExecute function with options instead.
```

## Root cause
`tryExecuteAndNotify` changed its return format in Umbraco 16+: instead of wrapping the response as `{ data: T, error? }`, it returns `T` directly. The `normalizeResponse` function only detected this for `ApiResponse` types (which have an `isSuccess` property), but not for the `Response` type returned by `saveConfiguration`, `testConfigurationConnection`, and `getEnterspeedConfiguration` (which have `success` instead).

This caused a cascade of failures:
1. `response.data?.success` was `undefined` → fell through to `notifyErrors()`
2. `notifyErrors()` threw a `TypeError` on `response.data.statusCode`
3. The `TypeError` was caught by `.catch()`, where `error.data.message` threw again → crash at line 128
4. No toast shown

## Changes

### `enterspeed.repository.ts`
- Fixed `normalizeResponse` to also detect `Response`-typed results in U16+/U17 by checking for `success` without a `data` property
- Replaced `tryExecuteAndNotify` with a version-aware `executeResource` wrapper:
  - Umbraco 14–16: calls `tryExecute(promise)`
  - Umbraco 17+: calls `tryExecute(host, promise, options)`
  - Detection is done via `tryExecute.length` at runtime, keeping a single codebase for all supported versions

### `settings-dashboard.ts`
- Hardened all `.catch` handlers to use safe access (`error?.data?.message ?? error?.message ?? "..."`) preventing secondary crashes when the caught value is a `TypeError` rather than an API error

## Acceptance criteria
- [x] All usages of `tryExecuteAndNotify` are replaced with `tryExecute` using the appropriate options parameter
- [x] No deprecation warnings appear in the browser console when interacting with the Enterspeed settings dashboard on Umbraco 17.x
- [ ] The package builds and runs without errors on Umbraco 18.0.0 (or its release candidate)

## Testing
1. Open the Enterspeed settings dashboard in Umbraco 17
2. Change any field and click **Save configuration** → success toast should appear
3. Verify no deprecation warnings in the browser console

## Notes
- Umbraco 18.0.0 releases **June 25, 2026** — the `tryExecuteAndNotify` removal will be a hard break for users upgrading. The version-aware wrapper future-proofs the package until it can be verified against an Umbraco 18 RC.
- Security: low risk — this is a framework API migration with no auth, data exposure, or input validation implications.

Story details: https://app.shortcut.com/enterspeed/story/8619