### PR TITLE
Report which API key failed when saving or testing the configuration

### DIFF
--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/dashboards/settings/settings-dashboard.ts
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/dashboards/settings/settings-dashboard.ts
@@ -1,4 +1,7 @@
 import "../shared/server-message.element";
+import "../shared/notification-list.element";
+
+import type { EnterspeedNotificationListData } from "../shared/notification-list.element";
 
 import {
   html,
@@ -17,6 +20,10 @@ import {
   EnterspeedUmbracoConfigurationResponse,
 } from "../../generated";
 
+// Subset of Umbraco's UmbNotificationColor that this dashboard uses. Declared locally rather than imported so it does
+// not depend on the type being exported under the same name across Umbraco 14-17.
+type NotificationColor = "positive" | "warning" | "danger";
+
 @customElement("enterspeed-settings-dashboard")
 export class enterspeedSettingsDashboard extends UmbLitElement {
   #enterspeedContext: EnterspeedContext;
@@ -26,14 +33,15 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
     | EnterspeedUmbracoConfigurationResponse
     | null
     | undefined;
-  #buttonState: string;
 
   @state()
   loadingConfiguration = true;
 
+  @state()
+  buttonState = "";
+
   constructor() {
     super();
-    this.#buttonState = "";
 
     this.consumeContext(
       UMB_NOTIFICATION_CONTEXT,
@@ -43,26 +51,24 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
     );
 
     this.#enterspeedContext = new EnterspeedContext(this);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
     this.getConfiguration();
   }
 
-  getConfiguration() {
-    this.#buttonState = "busy";
-    this.#enterspeedContext
-      .getEnterspeedConfiguration()
-      .then((response) => {
-        this.#enterspeedConfiguration = response.data?.data?.configuration;
-        this.loadingConfiguration = false;
-      })
-      .catch((error) => {
-        this.#notificationContext?.peek("danger", {
-          data: {
-            headline: "Error loading configuration",
-            message: error?.data?.message ?? error?.message ?? "An unexpected error occurred",
-          },
-        });
-      });
-    this.#buttonState = "";
+  async getConfiguration() {
+    this.buttonState = "busy";
+    try {
+      const response = await this.#enterspeedContext.getEnterspeedConfiguration();
+      this.#enterspeedConfiguration = response.data?.data?.configuration;
+      this.loadingConfiguration = false;
+    } catch (error) {
+      this.#notify("danger", "Error loading configuration", this.#messageFrom(error));
+    } finally {
+      this.buttonState = "";
+    }
   }
 
   async testConfigurationConnection() {
@@ -70,92 +76,155 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
       !this.#enterspeedConfiguration?.apiKey ||
       !this.#enterspeedConfiguration.baseUrl
     ) {
-      this.#notificationContext?.peek("danger", {
-        data: {
-          message: "Missing api key or base url",
-        },
-      });
+      this.#notify("danger", "Cannot test connection", "Enter an API key and a base url first.");
       return;
     }
 
-    this.#buttonState = "busy";
-    this.#enterspeedContext
-      .testConfigurationConnection(this.#enterspeedConfiguration)
-      .then((response) => {
-        if (response.data?.success) {
-          this.#notificationContext?.peek("positive", {
-            data: {
-              headline: "Connection successful",
-              message: "The connection to Enterspeed was successful.",
-            },
-          });
-        } else {
-          this.notifyErrors(response, "");
-        }
-      })
-      .catch((error) => {
-        this.#notificationContext?.peek("danger", {
-          data: {
-            headline: "Connection failed",
-            message: error?.data?.message ?? error?.message ?? "An unexpected error occurred",
-          },
-        });
-      });
-
-    this.#buttonState = "";
+    this.buttonState = "busy";
+    try {
+      const response = await this.#enterspeedContext.testConfigurationConnection(
+        this.#enterspeedConfiguration
+      );
+      if (response.data?.success) {
+        this.#notify(
+          "positive",
+          "Connection successful",
+          response.data.message ?? "The connection to Enterspeed was successful."
+        );
+      } else {
+        // Publishing still works when only the preview key fails, so that is not a failed connection.
+        this.#notifyFailure(response, "Connection failed", "Preview connection failed");
+      }
+    } catch (error) {
+      this.#notify("danger", "Connection failed", this.#messageFrom(error));
+    } finally {
+      this.buttonState = "";
+    }
   }
 
   async saveConfiguration() {
-    if (this.#enterspeedConfiguration != null) {
-      this.#enterspeedContext
-        .saveConfiguration(this.#enterspeedConfiguration)
-        .then((response) => {
-          if (response.data?.success) {
-            this.#notificationContext?.peek("positive", {
-              data: {
-                headline: "Configuration saved",
-                message: "The configuration has been saved.",
-              },
-            });
-          } else {
-            this.notifyErrors(response, "Error saving configuration");
-          }
-        })
-        .catch((error) => {
-          this.#notificationContext?.peek("danger", {
-            data: {
-              headline: "Error saving configuration",
-              message: error?.data?.message ?? error?.message ?? "An unexpected error occurred",
-            },
-          });
-        });
+    if (this.#enterspeedConfiguration == null) {
+      return;
+    }
+
+    this.buttonState = "busy";
+    try {
+      const response = await this.#enterspeedContext.saveConfiguration(
+        this.#enterspeedConfiguration
+      );
+      if (response.data?.success) {
+        // An invalid preview api key does not block the save, so it comes back as a success carrying errors.
+        const errors = response.data.errors;
+        if (errors && Object.keys(errors).length > 0) {
+          this.#notifyList(
+            "warning",
+            "Configuration saved",
+            this.#keyStatuses(errors),
+            this.#hint(errors)
+          );
+        } else {
+          this.#notify(
+            "positive",
+            "Configuration saved",
+            response.data.message ?? "The configuration has been saved."
+          );
+        }
+      } else {
+        this.#notifyFailure(response, "Error saving configuration");
+      }
+    } catch (error) {
+      this.#notify("danger", "Error saving configuration", this.#messageFrom(error));
+    } finally {
+      this.buttonState = "";
     }
   }
 
-  notifyErrors(response: any, errorMessage: string) {
-    let status = response.data.statusCode;
-    errorMessage = errorMessage || "Something went wrong";
-    if (status === 401) {
-      this.#notificationContext?.peek("danger", {
-        data: {
-          headline: "Error saving configuration",
-          message: response.data.message ?? "Unknown error",
-        },
-      });
-    } else if (status === 404) {
-      this.#notificationContext?.peek("danger", {
-        data: {
-          message: "Url does not exist",
-        },
-      });
+  // Reports whatever the server returned rather than branching on the status code. A failing publish api key is an
+  // error; a preview-only failure leaves publishing working, so it is only a warning.
+  #notifyFailure(response: any, headline: string, warningHeadline?: string) {
+    const errors = response?.data?.errors;
+    const publishFailed = !errors || "publishApiKey" in errors;
+    const statuses = this.#keyStatuses(errors);
+
+    if (statuses.length > 0) {
+      this.#notifyList(
+        publishFailed ? "danger" : "warning",
+        publishFailed ? headline : warningHeadline ?? headline,
+        statuses,
+        this.#hint(errors)
+      );
     } else {
-      this.#notificationContext?.peek("danger", {
-        data: {
-          message: errorMessage,
-        },
-      });
+      this.#notify(
+        publishFailed ? "danger" : "warning",
+        headline,
+        this.#messageFrom(response)
+      );
     }
   }
+
+  // Reports every key that was checked rather than only the failures, so a mixed result also confirms which key does
+  // work. Only meaningful when the server returned per key errors - without them the request never reached validation,
+  // and claiming a key is valid would be a guess.
+  #keyStatuses(errors: Record<string, string | null> | null | undefined) {
+    if (!errors || Object.keys(errors).length === 0) {
+      return [];
+    }
+
+    const statuses = [errors.publishApiKey ?? "Publish API key is valid"];
+    if (this.#enterspeedConfiguration?.previewApiKey) {
+      statuses.push(errors.previewApiKey ?? "Preview API key is valid");
+    }
+
+    return statuses;
+  }
+
+  #hint(errors: Record<string, string | null> | null | undefined) {
+    const failures = errors
+      ? Object.values(errors).filter(Boolean).length
+      : 0;
+
+    return failures > 1
+      ? "Verify your API keys under Settings > Data sources in the Enterspeed app."
+      : "Verify the API key under Settings > Data sources in the Enterspeed app.";
+  }
+
+  #messageFrom(source: any) {
+    return (
+      source?.data?.message ??
+      source?.error?.message ??
+      source?.message ??
+      "An unexpected error occurred"
+    );
+  }
+
+  #notify(color: NotificationColor, headline: string, message: string) {
+    this.#notificationContext?.peek(color, {
+      data: { headline, message },
+    });
+  }
+
+  // Uses the list layout so each key reads as its own line rather than one paragraph. The hint is given once here
+  // instead of being repeated in every message. `message` is kept populated so the payload still satisfies Umbraco's
+  // default notification data, which is what renders if the custom element is ever unavailable.
+  #notifyList(
+    color: NotificationColor,
+    headline: string,
+    messages: string[],
+    hint: string
+  ) {
+    const data: EnterspeedNotificationListData & { message: string } = {
+      headline,
+      messages,
+      hint,
+      message: messages.join(" "),
+    };
+
+    this.#notificationContext?.peek(color, {
+      elementName: "enterspeed-notification-list",
+      data,
+    });
+  }
+
 
   render() {
     if (!this.loadingConfiguration) {
@@ -189,7 +258,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
               placeholder="Enterspeed base url"
               label="enterspeed base url"
               .disabled=${this.#enterspeedConfiguration
-          ?.configuredFromSettingsFile || this.#buttonState === "busy"}
+          ?.configuredFromSettingsFile || this.buttonState === "busy"}
               .value=${this.#enterspeedConfiguration?.baseUrl}
               @input="${(e: any) => {
           this.#enterspeedConfiguration!.baseUrl = e.target.value;
@@ -211,7 +280,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
               placeholder="Media domain (optional)"
               label="Media domain (optional)"
               .disabled=${this.#enterspeedConfiguration
-          ?.configuredFromSettingsFile || this.#buttonState === "busy"}
+          ?.configuredFromSettingsFile || this.buttonState === "busy"}
               .value=${this.#enterspeedConfiguration?.mediaDomain ?? ""}
               @input="${(e: any) => {
           this.#enterspeedConfiguration!.mediaDomain = e.target.value;
@@ -236,7 +305,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
               placeholder="Enterspeed API Key"
               label="Enterspeed API Key"
               .disabled=${this.#enterspeedConfiguration
-          ?.configuredFromSettingsFile || this.#buttonState === "busy"}
+          ?.configuredFromSettingsFile || this.buttonState === "busy"}
               .value=${this.#enterspeedConfiguration?.apiKey ?? ""}
               @input="${(e: any) => {
           this.#enterspeedConfiguration!.apiKey = e.target.value;
@@ -257,7 +326,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
               placeholder="Enterspeed preview API Key (optional)"
               label="Enterspeed preview API Key (optional)"
               .disabled=${this.#enterspeedConfiguration
-          ?.configuredFromSettingsFile || this.#buttonState === "busy"}
+          ?.configuredFromSettingsFile || this.buttonState === "busy"}
               .value=${this.#enterspeedConfiguration?.previewApiKey ?? ""}
               @input="${(e: any) => {
           this.#enterspeedConfiguration!.previewApiKey = e.target.value;
@@ -272,7 +341,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
               look="primary"
               color="positive"
               label="Basic"
-              .disabled=${this.#buttonState == "busy" ||
+              .disabled=${this.buttonState == "busy" ||
         !this.#enterspeedConfiguration?.apiKey ||
         !this.#enterspeedConfiguration?.baseUrl ||
         this.#enterspeedConfiguration?.configuredFromSettingsFile}
@@ -285,7 +354,7 @@ export class enterspeedSettingsDashboard extends UmbLitElement {
               look="primary"
               color="default"
               label="Basic"
-              .disabled=${this.#buttonState == "busy" ||
+              .disabled=${this.buttonState == "busy" ||
         !this.#enterspeedConfiguration?.apiKey ||
         !this.#enterspeedConfiguration?.baseUrl}
               @click="${() => this.testConfigurationConnection()}"

--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/dashboards/shared/notification-list.element.ts
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/assets/src/dashboards/shared/notification-list.element.ts
@@ -1,0 +1,64 @@
+import {
+  html,
+  css,
+  customElement,
+  property,
+  ifDefined,
+  nothing,
+} from "@umbraco-cms/backoffice/external/lit";
+import { UmbLitElement } from "@umbraco-cms/backoffice/lit-element";
+
+export interface EnterspeedNotificationListData {
+  headline?: string;
+  messages: string[];
+  hint?: string;
+}
+
+/**
+ * Notification layout that lists each message on its own line. Umbraco's default layout renders the message as a
+ * single block of text, which is hard to read when more than one thing failed. Pass the element name to `peek`:
+ *
+ *   peek("danger", { elementName: "enterspeed-notification-list", data: { headline, messages } })
+ */
+@customElement("enterspeed-notification-list")
+export class enterspeedNotificationList extends UmbLitElement {
+  @property({ attribute: false })
+  data?: EnterspeedNotificationListData;
+
+  render() {
+    return html`<uui-toast-notification-layout
+      headline=${ifDefined(this.data?.headline)}
+      class="uui-text"
+    >
+      <ul id="messages">
+        ${this.data?.messages.map((message) => html`<li>${message}</li>`)}
+      </ul>
+      ${this.data?.hint ? html`<p id="hint">${this.data.hint}</p>` : nothing}
+    </uui-toast-notification-layout>`;
+  }
+
+  static styles = css`
+    /* Set explicitly, as the backoffice styles strip list markers from ul elements. */
+    #messages {
+      list-style: disc outside;
+      margin: 0;
+      padding-left: 18px;
+    }
+
+    #messages li + li {
+      margin-top: 3px;
+    }
+
+    #hint {
+      margin: 6px 0 0;
+    }
+  `;
+}
+
+export default enterspeedNotificationList;
+
+declare global {
+  interface HTMLElementTagNameMap {
+    "enterspeed-notification-list": enterspeedNotificationList;
+  }
+}

--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/readme.md
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/Client/readme.md
@@ -5,20 +5,59 @@
 
 ## Development
 
-1. Set up an Umbraco 14+ website and reference the `Enterspeed.Source.UmbracoCMS.V14PLUS` .NET project.
-2. Launch your Umbraco website.
-3. Run `npm run watch` to compile frontend changes.
+Testing local changes means running an Umbraco 14+ website against the projects in this repository instead of against the released NuGet package.
 
-    This command monitors your files for changes, automatically compiles, and moves them to the `wwwroot` folder in the `Enterspeed.Source.UmbracoCms.V14Plus` project.
+### 1. Reference the projects
 
-4. Changed frontend files in `Enterspeed.Source.UmbracoCms.V14Plus` should be visible in your Umbraco website since static web assets in the project will be picked up by your Umbraco instance.
+In your Umbraco website:
+
+1. If the website already references the `Enterspeed.Source.UmbracoCms` NuGet package, remove that `PackageReference` - otherwise the released package and these projects would both be referenced. A newly created website will not have it.
+2. Add a `ProjectReference` to **both** `Enterspeed.Source.UmbracoCms.V14Plus` **and** `Enterspeed.Source.UmbracoCms.Base`.
+
+   `Base` has to be referenced explicitly. `Enterspeed.Source.UmbracoCms.V14Plus` references it with `PrivateAssets="all"` so the `CopyProjectReferencesToPackage` target can bundle `Base.dll` into the NuGet package, which also means it does not flow on to a project that references `V14Plus`.
+
+3. Rebuild the website. Swapping a `PackageReference` for a `ProjectReference` usually needs a full rebuild before the assemblies are picked up.
+
+### 2. Make App_Plugins available
+
+The NuGet package copies the client assets into the consuming website through `build/Enterspeed.Source.UmbracoCms.targets`. MSBuild only applies a package's `build` targets for a `PackageReference`, so with a project reference **nothing is copied and the Enterspeed dashboards will not load at all** - `/App_Plugins/Enterspeed.Source.UmbracoCms/umbraco-package.json` returns 404.
+
+Link the folder instead, so the built assets are served straight out of this repository. Run once:
+
+```
+mklink /J "<your-umbraco-website>\App_Plugins\Enterspeed.Source.UmbracoCms" "<this-repository>\src\Enterspeed.Source.UmbracoCms.V14Plus\wwwroot\App_Plugins\Enterspeed.Source.UmbracoCms"
+```
+
+`App_Plugins` belongs at the root of your Umbraco project, next to `wwwroot`, not inside it. The target folder must not already exist - if the NuGet package was previously installed it will have left a copy of the assets behind, so delete that folder first. Copying the folder by hand works too, but has to be repeated after every frontend build, because the compiled filenames are content hashed and change with the content.
+
+### 3. Run
+
+1. Run `npm run watch` in `Client\assets`.
+
+   This command monitors your files for changes, automatically compiles, and moves them to the `wwwroot` folder in the `Enterspeed.Source.UmbracoCms.V14Plus` project.
+
+2. Launch your Umbraco website and log in to the backoffice.
+
+**Work with `Disable cache` ticked in the browser's network tools, and leave the tools open.** `umbraco-package.json` points at `assets.js`, which is the only file whose name never changes - every other compiled file is content hashed. A cached `assets.js` therefore keeps importing the file names it was built with, so your changes silently never appear and the dashboards keep working from the previous build. Clearing site data does not necessarily help, because it leaves the HTTP cache in place.
+
+To check which build the browser is actually running, look for `assets.js` in the network tools. If it says it came from cache rather than returning 200 or 304, that is the problem.
+
+Changes to C# need the website rebuilt and restarted.
+
+If the dashboards do not show up at all, check that `/App_Plugins/Enterspeed.Source.UmbracoCms/umbraco-package.json` returns 200 - a 404 means step 2 is missing.
+
+### Good to know
+
+- When building `Enterspeed.Source.UmbracoCms.V14Plus` directly, build it with `-f net8.0`. The other target frameworks regenerate `appsettings-schema.Umbraco.Cms.json` and `umbraco-package-schema.json` against a different Umbraco version, which produces a very large and unrelated diff. Those two files are development time IntelliSense helpers and are not part of the published package.
 
 ## Additional Information
+
 All types are auto-generated based on the API specs from `Enterspeed.Source.UmbracoCMS.V14PLUS`.
 To generate new types after recent API changes, run the following command:
+
 - `npm run generate`.
 
-**Important** 
+**Important**
 
 The command points at the path `http://localhost:46983/umbraco/swagger/enterspeed/swagger.json`.
 

--- a/src/Enterspeed.Source.UmbracoCms.V14Plus/Controllers/DashboardController.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V14Plus/Controllers/DashboardController.cs
@@ -29,6 +29,12 @@ namespace Enterspeed.Source.UmbracoCms.V14Plus.Controllers
     [ApiExplorerSettings(GroupName = "Dashboard")]
     public class DashboardController : EnterspeedBaseController
     {
+        internal const string PublishApiKeyError = "publishApiKey";
+        internal const string PreviewApiKeyError = "previewApiKey";
+
+        private const string PublishKeyName = "Publish";
+        private const string PreviewKeyName = "Preview";
+
         private readonly IServerRoleAccessor _serverRoleAccessor;
         private readonly IEnterspeedJobsHandlingService _enterspeedJobsHandlingService;
         private readonly IEnterspeedJobRepository _enterspeedJobRepository;
@@ -162,10 +168,13 @@ namespace Enterspeed.Source.UmbracoCms.V14Plus.Controllers
                         .GetLeftPart(UriPartial.Authority);
             }
 
-            var response = TestConnection(configuration);
-            if (!response.Success)
+            var validation = ValidateConfiguration(configuration);
+
+            // The publish API key is required, so nothing is saved when it is invalid. An invalid preview API key only
+            // disables preview, so the configuration is still saved and the failure is reported as a warning.
+            if (validation.Errors != null && validation.Errors.ContainsKey(PublishApiKeyError))
             {
-                return Ok(response);
+                return Ok(validation);
             }
 
             try
@@ -190,7 +199,9 @@ namespace Enterspeed.Source.UmbracoCms.V14Plus.Controllers
                 new Response
                 {
                     Status = HttpStatusCode.OK,
-                    Success = true
+                    Success = true,
+                    Message = validation.Message,
+                    Errors = validation.Errors
                 });
         }
 
@@ -276,32 +287,95 @@ namespace Enterspeed.Source.UmbracoCms.V14Plus.Controllers
         [ProducesResponseType(typeof(Response), 200)]
         public IActionResult TestConfigurationConnection(EnterspeedUmbracoConfiguration configuration)
         {
-            return Ok(TestConnections(configuration));
+            return Ok(ValidateConfiguration(configuration));
         }
 
-        private Response TestConnections(EnterspeedUmbracoConfiguration configuration)
+        // Both keys are always checked, so a single request reports the state of both, per key in Response.Errors.
+        private Response ValidateConfiguration(EnterspeedUmbracoConfiguration configuration)
         {
-            var publishConfiguration = configuration.GetPublishConfiguration();
-            var previewConfiguration = configuration.GetPreviewConfiguration();
+            var errors = new Dictionary<string, string>();
+            Response failedResponse = null;
+            var publishRejected = false;
+            var previewRejected = false;
 
-            var publishResponse = TestConnection(publishConfiguration);
-            if (!publishResponse.Success || previewConfiguration == null)
+            var publishKeyMissing = DescribeMissingKey(configuration.ApiKey, PublishKeyName);
+            if (publishKeyMissing != null)
             {
-                if (!publishResponse.Success && publishResponse.StatusCode == 401)
+                errors.Add(PublishApiKeyError, publishKeyMissing);
+            }
+            else
+            {
+                var publishResponse = TestConnection(configuration.GetPublishConfiguration());
+                if (!publishResponse.Success)
                 {
-                    publishResponse.Message = "Publish API key is invalid";
+                    errors.Add(PublishApiKeyError, DescribeFailure(publishResponse, PublishKeyName));
+                    publishRejected = publishResponse.StatusCode == 401;
+                    failedResponse = publishResponse;
                 }
-
-                return publishResponse;
             }
 
-            var previewResponse = TestConnection(previewConfiguration);
-            if (!previewResponse.Success && previewResponse.StatusCode == 401)
+            // The preview API key is optional, so it is only verified when one has been entered.
+            var previewConfigured = !string.IsNullOrWhiteSpace(configuration.PreviewApiKey);
+            if (previewConfigured)
             {
-                previewResponse.Message = "Preview API key is invalid";
+                var previewResponse = TestConnection(configuration.GetPreviewConfiguration());
+                if (!previewResponse.Success)
+                {
+                    errors.Add(PreviewApiKeyError, DescribeFailure(previewResponse, PreviewKeyName));
+                    previewRejected = previewResponse.StatusCode == 401;
+                    failedResponse ??= previewResponse;
+                }
             }
 
-            return previewResponse;
+            if (errors.Count == 0)
+            {
+                return new Response
+                {
+                    Status = HttpStatusCode.OK,
+                    Success = true,
+                    Message = previewConfigured
+                        ? "Publish and preview API keys are valid"
+                        : "Publish API key is valid"
+                };
+            }
+
+            // Both keys rejected for the same reason is said once, rather than repeating the same sentence per key.
+            var bothRejected = publishRejected && previewRejected;
+            var statements = bothRejected
+                ? "Publish and preview API keys were rejected by Enterspeed"
+                : string.Join(". ", errors.Values);
+
+            return new Response
+            {
+                Status = failedResponse?.Status ?? HttpStatusCode.BadRequest,
+                Success = false,
+                Message = $"{statements}. {DescribeAdvice(errors.Count)}",
+                Errors = errors,
+                Exception = failedResponse?.Exception
+            };
+        }
+
+        private static string DescribeAdvice(int failureCount) => failureCount > 1
+            ? "The keys are either incorrect or not valid API keys - please verify them in the Enterspeed app."
+            : "The key is either incorrect or not a valid API key - please verify it in the Enterspeed app.";
+
+        // Only checks presence. Validating the key format is left to Enterspeed, so a format change there does not
+        // need a release of this package.
+        private static string DescribeMissingKey(string apiKey, string keyName) =>
+            string.IsNullOrWhiteSpace(apiKey) ? $"{keyName} API key is required" : null;
+
+        // Prefers the message Enterspeed returned. It sends no body for an unauthorized request today, hence the
+        // fallbacks, which cannot tell an unrecognised key from a malformed one.
+        private static string DescribeFailure(Response response, string keyName)
+        {
+            if (!string.IsNullOrWhiteSpace(response.Message))
+            {
+                return $"{keyName} API key: {response.Message}";
+            }
+
+            return response.StatusCode == 401
+                ? $"{keyName} API key was rejected by Enterspeed"
+                : $"{keyName} API key could not be verified (HTTP {response.StatusCode})";
         }
 
         private Response TestConnection(EnterspeedConfiguration configuration)

--- a/src/Enterspeed.Source.UmbracoCms.V9Plus/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/enterspeed-configuration.controller.js
+++ b/src/Enterspeed.Source.UmbracoCms.V9Plus/App_Plugins/Enterspeed.Dashboard/Dashboard.Sub.Controllers/enterspeed-configuration.controller.js
@@ -1,4 +1,4 @@
-﻿function enterspeedConfigurationController(enterspeedDashboardResources, notificationsService, $scope, $filter, $timeout) {
+function enterspeedConfigurationController(enterspeedDashboardResources, notificationsService, $scope, $filter, $timeout) {
     var vm = this;
     vm.loadingConfiguration = false;
     vm.buttonState = null;
@@ -21,68 +21,121 @@
                     vm.configuration.configuredFromSettingsFile = result.data.data.configuration.configuredFromSettingsFile;
                     vm.runJobsOnServer = result.data.data.runJobsOnServer;
                     vm.serverRole = result.data.data.serverRole;
-                    vm.loadingConfiguration = false;
-                    vm.buttonState = null;
+                } else {
+                    notificationsService.error("Error loading configuration", messageFrom(result));
                 }
+            })
+            .catch(function (error) {
+                notificationsService.error("Error loading configuration", messageFrom(error));
+            })
+            .finally(function () {
+                vm.loadingConfiguration = false;
+                vm.buttonState = null;
             });
     };
 
     vm.saveConfiguration = function () {
-        vm.buttonState = "busy";
         if (!vm.configuration.apiKey || !vm.configuration.baseUrl) {
-            notificationsService.error("Add api key and base url");
-            vm.buttonState = null;
+            notificationsService.error("Cannot save configuration", "Enter an api key and a base url first.");
             return;
         }
 
+        vm.buttonState = "busy";
         enterspeedDashboardResources.saveEnterspeedConfiguration(vm.configuration)
             .then(function (result) {
                 if (result.data.success) {
-                    notificationsService.success("Configuration saved");
+                    // An invalid preview api key does not block the save, so it comes back as a success carrying errors.
+                    const errors = result.data.errors;
+                    if (errors && Object.keys(errors).length > 0) {
+                        notificationsService.warning("Configuration saved", keyStatuses(errors));
+                    } else {
+                        notificationsService.success("Configuration saved", result.data.message || "The configuration has been saved.");
+                    }
+
                     vm.setPristine();
                 } else {
-                    notifyErrors(result.data, "Error saving configuration");
+                    notifyFailure(result, "Error saving configuration");
                 }
-                vm.buttonState = null;
             })
             .catch(function (error) {
-                console.error(error);
-                notifyErrors(error.data, `Error saving configuration: ${error.data.message}`);
+                notificationsService.error("Error saving configuration", messageFrom(error));
+            })
+            .finally(function () {
                 vm.buttonState = null;
             });
     };
 
     vm.testConnection = function () {
-        vm.buttonState = "busy";
-
         if (!vm.configuration.apiKey || !vm.configuration.baseUrl) {
-            notificationsService.error("Missing api key or base url");
-            vm.buttonState = null;
+            notificationsService.error("Cannot test connection", "Enter an api key and a base url first.");
             return;
         }
 
-        enterspeedDashboardResources.testEnterspeedConfiguration(vm.configuration).then(function (result) {
-            if (result.data.success) {
-                notificationsService.success("Connection succeeded");
-            } else {
-                notifyErrors(result.data);
-            }
-            vm.buttonState = null;
-        });
+        vm.buttonState = "busy";
+        enterspeedDashboardResources.testEnterspeedConfiguration(vm.configuration)
+            .then(function (result) {
+                if (result.data.success) {
+                    notificationsService.success("Connection successful", result.data.message || "The connection to Enterspeed was successful.");
+                } else {
+                    // Publishing still works when only the preview key fails, so that is not a failed connection.
+                    notifyFailure(result, "Connection failed", "Preview connection failed");
+                }
+            })
+            .catch(function (error) {
+                notificationsService.error("Connection failed", messageFrom(error));
+            })
+            .finally(function () {
+                vm.buttonState = null;
+            });
     };
 
-    function notifyErrors(data, errorMessage) {
-        var status = data.statusCode;
+    // Reports whatever the server returned rather than branching on the status code. A publish failure is an error,
+    // whereas a preview only failure still leaves publishing working and is reported as a warning.
+    function notifyFailure(result, headline, warningHeadline) {
+        const errors = result?.data?.errors;
+        const message = keyStatuses(errors) || messageFrom(result);
 
-        errorMessage = errorMessage || "Something went wrong";
-
-        if (status === 401) {
-            notificationsService.error(data.message);
-        } else if (status === 404) {
-            notificationsService.error("Url does not exist");
+        if (!errors || errors.publishApiKey) {
+            notificationsService.error(headline, message);
         } else {
-            notificationsService.error(errorMessage);
+            notificationsService.warning(warningHeadline || headline, message);
         }
+    }
+
+    // Adds the keys that passed, so a mixed result also confirms which key does work. Returns null when there is
+    // nothing to add - either the request never reached validation, or every key failed, in which case the message the
+    // server composed is already the better wording.
+    function keyStatuses(errors) {
+        if (!errors || Object.keys(errors).length === 0) {
+            return null;
+        }
+
+        const statuses = [];
+        if (!errors.publishApiKey) {
+            statuses.push("Publish API key is valid");
+        }
+        if (vm.configuration.previewApiKey && !errors.previewApiKey) {
+            statuses.push("Preview API key is valid");
+        }
+
+        if (statuses.length === 0) {
+            return null;
+        }
+
+        if (errors.publishApiKey) {
+            statuses.unshift(errors.publishApiKey);
+        }
+        if (errors.previewApiKey) {
+            statuses.push(errors.previewApiKey);
+        }
+
+        return statuses.join(". ") + ". Verify your API keys under Settings > Data sources in the Enterspeed app.";
+    }
+
+    function messageFrom(source) {
+        return source?.data?.message
+            || source?.message
+            || "An unexpected error occurred";
     }
 
     vm.setPristine = function () {

--- a/src/Enterspeed.Source.UmbracoCms.V9Plus/Controllers/Api/DashboardApiController.cs
+++ b/src/Enterspeed.Source.UmbracoCms.V9Plus/Controllers/Api/DashboardApiController.cs
@@ -26,6 +26,12 @@ namespace Enterspeed.Source.UmbracoCms.V9Plus.Controllers.Api
     [JsonCamelCaseFormatter]
     public class DashboardApiController : UmbracoAuthorizedApiController
     {
+        internal const string PublishApiKeyError = "publishApiKey";
+        internal const string PreviewApiKeyError = "previewApiKey";
+
+        private const string PublishKeyName = "Publish";
+        private const string PreviewKeyName = "Preview";
+
         private readonly IServerRoleAccessor _serverRoleAccessor;
         private readonly IEnterspeedJobsHandlingService _enterspeedJobsHandlingService;
         private readonly IEnterspeedJobRepository _enterspeedJobRepository;
@@ -148,10 +154,13 @@ namespace Enterspeed.Source.UmbracoCms.V9Plus.Controllers.Api
                         .GetLeftPart(UriPartial.Authority);
             }
 
-            var response = TestConnection(configuration);
-            if (!response.Success)
+            var validation = ValidateConfiguration(configuration);
+
+            // The publish API key is required, so nothing is saved when it is invalid. An invalid preview API key only
+            // disables preview, so the configuration is still saved and the failure is reported as a warning.
+            if (validation.Errors != null && validation.Errors.ContainsKey(PublishApiKeyError))
             {
-                return Ok(response);
+                return Ok(validation);
             }
 
             try
@@ -176,7 +185,9 @@ namespace Enterspeed.Source.UmbracoCms.V9Plus.Controllers.Api
                 new Response
                 {
                     Status = HttpStatusCode.OK,
-                    Success = true
+                    Success = true,
+                    Message = validation.Message,
+                    Errors = validation.Errors
                 });
         }
 
@@ -252,32 +263,95 @@ namespace Enterspeed.Source.UmbracoCms.V9Plus.Controllers.Api
         [HttpPost]
         public IActionResult TestConfigurationConnection(EnterspeedUmbracoConfiguration configuration)
         {
-            return Ok(TestConnections(configuration));
+            return Ok(ValidateConfiguration(configuration));
         }
 
-        private Response TestConnections(EnterspeedUmbracoConfiguration configuration)
+        // Both keys are always checked, so a single request reports the state of both, per key in Response.Errors.
+        private Response ValidateConfiguration(EnterspeedUmbracoConfiguration configuration)
         {
-            var publishConfiguration = configuration.GetPublishConfiguration();
-            var previewConfiguration = configuration.GetPreviewConfiguration();
+            var errors = new Dictionary<string, string>();
+            Response failedResponse = null;
+            var publishRejected = false;
+            var previewRejected = false;
 
-            var publishResponse = TestConnection(publishConfiguration);
-            if (!publishResponse.Success || previewConfiguration == null)
+            var publishKeyMissing = DescribeMissingKey(configuration.ApiKey, PublishKeyName);
+            if (publishKeyMissing != null)
             {
-                if (!publishResponse.Success && publishResponse.StatusCode == 401)
+                errors.Add(PublishApiKeyError, publishKeyMissing);
+            }
+            else
+            {
+                var publishResponse = TestConnection(configuration.GetPublishConfiguration());
+                if (!publishResponse.Success)
                 {
-                    publishResponse.Message = "Publish API key is invalid";
+                    errors.Add(PublishApiKeyError, DescribeFailure(publishResponse, PublishKeyName));
+                    publishRejected = publishResponse.StatusCode == 401;
+                    failedResponse = publishResponse;
                 }
-
-                return publishResponse;
             }
 
-            var previewResponse = TestConnection(previewConfiguration);
-            if (!previewResponse.Success && previewResponse.StatusCode == 401)
+            // The preview API key is optional, so it is only verified when one has been entered.
+            var previewConfigured = !string.IsNullOrWhiteSpace(configuration.PreviewApiKey);
+            if (previewConfigured)
             {
-                previewResponse.Message = "Preview API key is invalid";
+                var previewResponse = TestConnection(configuration.GetPreviewConfiguration());
+                if (!previewResponse.Success)
+                {
+                    errors.Add(PreviewApiKeyError, DescribeFailure(previewResponse, PreviewKeyName));
+                    previewRejected = previewResponse.StatusCode == 401;
+                    failedResponse = failedResponse ?? previewResponse;
+                }
             }
 
-            return previewResponse;
+            if (errors.Count == 0)
+            {
+                return new Response
+                {
+                    Status = HttpStatusCode.OK,
+                    Success = true,
+                    Message = previewConfigured
+                        ? "Publish and preview API keys are valid"
+                        : "Publish API key is valid"
+                };
+            }
+
+            // Both keys rejected for the same reason is said once, rather than repeating the same sentence per key.
+            var bothRejected = publishRejected && previewRejected;
+            var statements = bothRejected
+                ? "Publish and preview API keys were rejected by Enterspeed"
+                : string.Join(". ", errors.Values);
+
+            return new Response
+            {
+                Status = failedResponse?.Status ?? HttpStatusCode.BadRequest,
+                Success = false,
+                Message = $"{statements}. {DescribeAdvice(errors.Count)}",
+                Errors = errors,
+                Exception = failedResponse?.Exception
+            };
+        }
+
+        private static string DescribeAdvice(int failureCount) => failureCount > 1
+            ? "The keys are either incorrect or not valid API keys - please verify them in the Enterspeed app."
+            : "The key is either incorrect or not a valid API key - please verify it in the Enterspeed app.";
+
+        // Only checks presence. Validating the key format is left to Enterspeed, so a format change there does not
+        // need a release of this package.
+        private static string DescribeMissingKey(string apiKey, string keyName) =>
+            string.IsNullOrWhiteSpace(apiKey) ? $"{keyName} API key is required" : null;
+
+        // Prefers the message Enterspeed returned. It sends no body for an unauthorized request today, hence the
+        // fallbacks, which cannot tell an unrecognised key from a malformed one.
+        private static string DescribeFailure(Response response, string keyName)
+        {
+            if (!string.IsNullOrWhiteSpace(response.Message))
+            {
+                return $"{keyName} API key: {response.Message}";
+            }
+
+            return response.StatusCode == 401
+                ? $"{keyName} API key was rejected by Enterspeed"
+                : $"{keyName} API key could not be verified (HTTP {response.StatusCode})";
         }
 
         private Response TestConnection(EnterspeedConfiguration configuration)


### PR DESCRIPTION
## What

- `SaveConfiguration` and `TestConfigurationConnection` now share `ValidateConfiguration`, which checks both API keys and reports failures per key in `Response.Errors`
- The publish key is required and blocks the save; the preview key is optional, so an invalid one still saves and is reported as a warning
- Both dashboards report the state of every key checked, so a mixed result also confirms which key works
- A preview-only failure is reported as a warning rather than a failed connection
- Two keys rejected for the same reason are reported in one sentence rather than repeated per key
- Neither dashboard branches on status codes any more; both surface whatever the response carries, with defensive reads
- Both dashboards disable their buttons while a request is in flight
- Umbraco 14+ gains a notification layout that puts each key on its own line
- The client readme now documents running a local Umbraco website against these projects

## Why

Saving with an invalid API key reported `Unknown error`, because save used a code path that never mapped a 401 to a message. Testing the connection reported `Error saving configuration`, because both shared an error handler with a hardcoded headline. That handler also dereferenced `response.data.statusCode`, which threw `TypeError: Cannot read properties of undefined (reading 'message')` whenever a response carried no body.

## Test plan

- [x] `dotnet build` — V14Plus and V9Plus, net8.0
- [x] `npx tsc --noEmit` and `npm run build` in `Client/assets`
- [x] Umbraco 17: both keys invalid, mixed publish-valid/preview-invalid, list rendering and orange warning
- [x] Umbraco 13: both keys invalid, mixed, combined sentence, warning notification
- [x] Both keys valid

## Related

Closes sc-8620

Suggested version bump: 5.4.0 (Umbraco 14+) and 4.5.0 (Umbraco 9-13), applied in the separate release commit. Minor rather than patch because `Response.Errors` is now populated where it previously never was, which is additive information a consumer could rely on.
